### PR TITLE
chore: update links after Scikit-HEP migration

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,13 +4,13 @@ Your contributions to `cabinetry` are welcome. Thank you for your interest!
 
 ## Issues
 
-[Issues](https://github.com/alexander-held/cabinetry/issues) are a good place to report bugs, ask questions, request features, or discuss potential changes to `cabinetry`.
+[Issues](https://github.com/scikit-hep/cabinetry/issues) are a good place to report bugs, ask questions, request features, or discuss potential changes to `cabinetry`.
 Before opening a new issue, please have a look through existing issues to avoid duplications.
 Please also take a look at the [documentation](https://cabinetry.readthedocs.io/), which may answer some questions.
 
 ## Pull requests
 
-It can be helpful to first get into contact via issues before getting started with a [pull request](https://github.com/alexander-held/cabinetry/pulls).
+It can be helpful to first get into contact via issues before getting started with a [pull request](https://github.com/scikit-hep/cabinetry/pulls).
 All pull requests are squashed and merged, so feel free to commit as many times as you want to the branch you are working on.
 The final commit message should follow the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-<div align="center"><img src="https://raw.githubusercontent.com/alexander-held/cabinetry/master/docs/_static/cabinetry_logo_small.png" alt="cabinetry logo"></div>
+<div align="center"><img src="https://raw.githubusercontent.com/scikit-hep/cabinetry/master/docs/_static/cabinetry_logo_small.png" alt="cabinetry logo"></div>
 
-[![CI status](https://github.com/alexander-held/cabinetry/workflows/CI/badge.svg)](https://github.com/alexander-held/cabinetry/actions?query=workflow%3ACI)
+[![CI status](https://github.com/scikit-hep/cabinetry/workflows/CI/badge.svg)](https://github.com/scikit-hep/cabinetry/actions?query=workflow%3ACI)
 [![Documentation Status](https://readthedocs.org/projects/cabinetry/badge/?version=latest)](https://cabinetry.readthedocs.io/en/latest/?badge=latest)
-[![codecov](https://codecov.io/gh/alexander-held/cabinetry/branch/master/graph/badge.svg)](https://codecov.io/gh/alexander-held/cabinetry)
+[![codecov](https://codecov.io/gh/scikit-hep/cabinetry/branch/master/graph/badge.svg)](https://codecov.io/gh/scikit-hep/cabinetry)
 [![PyPI version](https://badge.fury.io/py/cabinetry.svg)](https://badge.fury.io/py/cabinetry)
 [![python version](https://img.shields.io/pypi/pyversions/cabinetry.svg)](https://pypi.org/project/cabinetry/)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.4742752.svg)](https://doi.org/10.5281/zenodo.4742752)
+[![Scikit-HEP](https://scikit-hep.org/assets/images/Scikit--HEP-Project-blue.svg)](https://scikit-hep.org/)
 
 `cabinetry` is a Python library for building and steering binned template fits.
 It is written with applications in High Energy Physics in mind.

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -2,7 +2,7 @@ Configuration schema
 ====================
 
 The configuration schema for ``cabinetry`` is given below.
-It is defined via a `json schema <https://json-schema.org/>`_ that can be found at `src/cabinetry/schemas/config.json <https://github.com/alexander-held/cabinetry/blob/master/src/cabinetry/schemas/config.json>`_.
+It is defined via a `json schema <https://json-schema.org/>`_ that can be found at `src/cabinetry/schemas/config.json <https://github.com/scikit-hep/cabinetry/blob/master/src/cabinetry/schemas/config.json>`_.
 
 The ``General`` block holds general settings, followed by blocks that take lists of objects: regions, samples, normalization factors, and systematics.
 The ``Regions``, ``Samples`` and ``NormFactors`` blocks are required, while ``Systematics`` is optional.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -27,7 +27,7 @@ This documentation can be viewed `on Read the Docs <https://cabinetry.readthedoc
     sphinx-build docs docs/_build
     open docs/_build/index.html
 
-See the `README on github <https://github.com/alexander-held/cabinetry/blob/master/README.md>`_ for a simple example of using ``cabinetry``, and the `cabinetry-tutorials <https://github.com/cabinetry/cabinetry-tutorials>`_ repository for a more in-depth version.
+See the `README on github <https://github.com/scikit-hep/cabinetry/blob/master/README.md>`_ for a simple example of using ``cabinetry``, and the `cabinetry-tutorials <https://github.com/cabinetry/cabinetry-tutorials>`_ repository for a more in-depth version.
 
 Presentations of cabinetry
 ----------------------------

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,7 +7,7 @@ long_description = file: README.md
 long_description_content_type = text/markdown
 license = BSD 3-Clause
 license_files = LICENSE
-url = https://github.com/alexander-held/cabinetry
+url = https://github.com/scikit-hep/cabinetry
 classifiers =
     Development Status :: 3 - Alpha
     Programming Language :: Python :: 3.7

--- a/src/cabinetry/schemas/config.json
+++ b/src/cabinetry/schemas/config.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://raw.githubusercontent.com/alexander-held/cabinetry/master/src/cabinetry/schemas/config.json",
+    "$id": "https://raw.githubusercontent.com/scikit-hep/cabinetry/master/src/cabinetry/schemas/config.json",
     "title": "cabinetry config schema",
     "description": "full schema for the cabinetry configuration file",
     "type": "object",


### PR DESCRIPTION
`cabinetry` has joined Scikit-HEP, and migrated from `alexander-held/cabinetry` to `scikit-hep/cabinetry`. This updates all links to point to the new repository, and adds a Scikit-HEP badge to the readme.

```
* updated links to point to new repository location scikit-hep/cabinetry
* added Scikit-HEP badge to readme
```