### PR TITLE
feat: make Filter property of regions optional

### DIFF
--- a/src/cabinetry/schemas/config.json
+++ b/src/cabinetry/schemas/config.json
@@ -105,14 +105,10 @@
             "$$target": "#/definitions/region",
             "description": "a region of phase space",
             "type": "object",
-            "required": ["Name", "Filter", "Variable", "Binning"],
+            "required": ["Name", "Variable", "Binning"],
             "properties": {
                 "Name": {
                     "description": "name of the region",
-                    "type": "string"
-                },
-                "Filter": {
-                    "description": "selection criteria to apply",
                     "type": "string"
                 },
                 "Variable": {
@@ -128,6 +124,10 @@
                         "type": "number"
                     },
                     "uniqueItems": true
+                },
+                "Filter": {
+                    "description": "selection criteria to apply",
+                    "type": "string"
                 },
                 "RegionPath": {
                     "description": "(part of) path to file containing region",
@@ -264,12 +264,12 @@
                     "description": "weight to apply (override for nominal setting)",
                     "type": "string"
                 },
-                "Filter": {
-                    "description": "selection criteria to apply (override for nominal setting)",
-                    "type": "string"
-                },
                 "Variable": {
                     "description": "variable to bin in (override for nominal setting)",
+                    "type": "string"
+                },
+                "Filter": {
+                    "description": "selection criteria to apply (override for nominal setting)",
                     "type": "string"
                 },
                 "RegionPath": {


### PR DESCRIPTION
Event filtering is not strictly required for model building, and as such should be optional. This changes the config schema to make the `Filter` property of regions optional to achieve this. The code already handles this scenario correctly, with a `None` filter passed through in this case.

```
* updated config schema to make the Filter property of regions optional
```