### PR TITLE
feat: sample-specific Filter overrides

### DIFF
--- a/src/cabinetry/schemas/config.json
+++ b/src/cabinetry/schemas/config.json
@@ -273,7 +273,7 @@
                     "type": "string"
                 },
                 "Filter": {
-                    "description": "selection criteria to apply (override for nominal setting)",
+                    "description": "selection criteria to apply (override for region / sample setting)",
                     "type": "string"
                 },
                 "RegionPath": {

--- a/src/cabinetry/schemas/config.json
+++ b/src/cabinetry/schemas/config.json
@@ -151,6 +151,10 @@
                     "description": "name of tree",
                     "type": "string"
                 },
+                "Filter": {
+                    "description": "selection criteria to apply (override for region setting)",
+                    "type": "string"
+                },
                 "Weight": {
                     "description": "weight to apply to events",
                     "type": "string"

--- a/src/cabinetry/template_builder.py
+++ b/src/cabinetry/template_builder.py
@@ -154,7 +154,8 @@ def _filter(
 
     Overrides the (optional) filter provided at the region level by a sample-specific
     filter, if provided. For non-nominal templates, overrides the nominal filter if an
-    alternative is specified for the template.
+    alternative is specified for the template. The systematic-specific filter overrides
+    the sample-specific filter if both are provided.
 
     Args:
         region (Dict[str, Any]): containing all region information

--- a/src/cabinetry/template_builder.py
+++ b/src/cabinetry/template_builder.py
@@ -152,8 +152,9 @@ def _filter(
 ) -> Optional[str]:
     """Returns the filter to be applied for event selection.
 
-    For non-nominal templates, overrides the nominal filter if an alternative is
-    specified for the template.
+    Overrides the (optional) filter provided at the region level by a sample-specific
+    filter, if provided. For non-nominal templates, overrides the nominal filter if an
+    alternative is specified for the template.
 
     Args:
         region (Dict[str, Any]): containing all region information
@@ -166,6 +167,12 @@ def _filter(
         Optional[str]: expression for the filter to be used, or None for no filtering
     """
     selection_filter = region.get("Filter", None)
+
+    # check for sample-specific overrides
+    selection_filter_override = sample.get("Filter", None)
+    if selection_filter_override is not None:
+        selection_filter = selection_filter_override
+
     # check whether a systematic is being processed
     if template is not None:
         # determine whether the template has an override specified

--- a/tests/test_template_builder.py
+++ b/tests/test_template_builder.py
@@ -170,6 +170,25 @@ def test__filter():
         == "jet_pt > 0"
     )
 
+    # sample-specific override
+    assert (
+        template_builder._filter(
+            {"Filter": "jet_pt > 0"}, {"Filter": "jet_pt > 100"}, {}, None
+        )
+        == "jet_pt > 100"
+    )
+
+    # sample-specific override, again overridden by systematic
+    assert (
+        template_builder._filter(
+            {"Filter": "jet_pt > 0"},
+            {"Filter": "jet_pt > 100"},
+            {"Name": "variation", "Up": {"Filter": "jet_pt > 200"}},
+            "Up",
+        )
+        == "jet_pt > 200"
+    )
+
 
 def test__weight():
     # no override


### PR DESCRIPTION
This adds an optional `Filter` property to samples. If a filter is specified at the sample level, it overrides the (optional) filter defined at the region level. Filter overrides could already previously exist at the systematic level, and these override the sample-level filter setting. In increasing order of priority, the filter used is specified at region -> sample -> systematic level.

```
* added optional Filter property to samples in config schema
* sample-level filters override region-level settings, and are overridden by systematics-level filters
``` 