### PR TITLE
fix: ratio panel in data/MC plots for bins with zero predicted yields

### DIFF
--- a/src/cabinetry/visualize/plot_model.py
+++ b/src/cabinetry/visualize/plot_model.py
@@ -134,13 +134,20 @@ def data_mc(
         linewidth=1,
     )  # reference line along y=1
 
+    n_zero_pred = sum(total_yield == 0.0)  # number of bins with zero predicted yields
+    if n_zero_pred > 0:
+        log.warning(
+            f"predicted yield is zero in {n_zero_pred} bin(s), excluded from ratio plot"
+        )
+
     # add uncertainty band around y=1
     rel_mc_unc = total_model_unc / total_yield
+    # do not show band in bins where total MC yield is 0
     ax2.bar(
-        bin_centers,
-        2 * rel_mc_unc,
-        width=bin_width,
-        bottom=1 - rel_mc_unc,
+        bin_centers[total_yield != 0.0],
+        2 * rel_mc_unc[total_yield != 0.0],
+        width=bin_width[total_yield != 0.0],
+        bottom=1.0 - rel_mc_unc[total_yield != 0.0],
         fill=False,
         linewidth=0,
         edgecolor="gray",
@@ -150,10 +157,11 @@ def data_mc(
     # data in ratio plot
     data_model_ratio = data_histogram_yields / total_yield
     data_model_ratio_unc = data_histogram_stdev / total_yield
+    # mask data in bins where total MC yield is 0
     ax2.errorbar(
-        bin_centers_data,
-        data_model_ratio,
-        yerr=data_model_ratio_unc,
+        bin_centers_data[total_yield != 0.0],
+        data_model_ratio[total_yield != 0.0],
+        yerr=data_model_ratio_unc[total_yield != 0.0],
         fmt="o",
         color="k",
     )

--- a/src/cabinetry/visualize/plot_model.py
+++ b/src/cabinetry/visualize/plot_model.py
@@ -142,7 +142,7 @@ def data_mc(
 
     # add uncertainty band around y=1
     rel_mc_unc = total_model_unc / total_yield
-    # do not show band in bins where total MC yield is 0
+    # do not show band in bins where total model yield is 0
     ax2.bar(
         bin_centers[total_yield != 0.0],
         2 * rel_mc_unc[total_yield != 0.0],
@@ -157,7 +157,7 @@ def data_mc(
     # data in ratio plot
     data_model_ratio = data_histogram_yields / total_yield
     data_model_ratio_unc = data_histogram_stdev / total_yield
-    # mask data in bins where total MC yield is 0
+    # mask data in bins where total model yield is 0
     ax2.errorbar(
         bin_centers_data[total_yield != 0.0],
         data_model_ratio[total_yield != 0.0],
@@ -168,7 +168,7 @@ def data_mc(
 
     # get the highest single bin yield, from the sum of MC or data
     y_max = max(np.amax(total_yield), np.amax(data_histogram_yields))
-    # lowest MC yield in single bin (not considering empty bins)
+    # lowest model yield in single bin (not considering empty bins)
     y_min = np.amin(total_yield[np.nonzero(total_yield)])
 
     # use log scale if it is requested, otherwise determine scale setting:

--- a/src/cabinetry/visualize/plot_model.py
+++ b/src/cabinetry/visualize/plot_model.py
@@ -139,15 +139,16 @@ def data_mc(
         log.warning(
             f"predicted yield is zero in {n_zero_pred} bin(s), excluded from ratio plot"
         )
+    nonzero_model_yield = total_yield != 0.0
 
     # add uncertainty band around y=1
     rel_mc_unc = total_model_unc / total_yield
     # do not show band in bins where total model yield is 0
     ax2.bar(
-        bin_centers[total_yield != 0.0],
-        2 * rel_mc_unc[total_yield != 0.0],
-        width=bin_width[total_yield != 0.0],
-        bottom=1.0 - rel_mc_unc[total_yield != 0.0],
+        bin_centers[nonzero_model_yield],
+        2 * rel_mc_unc[nonzero_model_yield],
+        width=bin_width[nonzero_model_yield],
+        bottom=1.0 - rel_mc_unc[nonzero_model_yield],
         fill=False,
         linewidth=0,
         edgecolor="gray",
@@ -159,9 +160,9 @@ def data_mc(
     data_model_ratio_unc = data_histogram_stdev / total_yield
     # mask data in bins where total model yield is 0
     ax2.errorbar(
-        bin_centers_data[total_yield != 0.0],
-        data_model_ratio[total_yield != 0.0],
-        yerr=data_model_ratio_unc[total_yield != 0.0],
+        bin_centers_data[nonzero_model_yield],
+        data_model_ratio[nonzero_model_yield],
+        yerr=data_model_ratio_unc[nonzero_model_yield],
         fmt="o",
         color="k",
     )

--- a/tests/visualize/test_plot_model.py
+++ b/tests/visualize/test_plot_model.py
@@ -123,7 +123,7 @@ def test_data_mc(tmp_path, caplog):
     ]
     caplog.clear()
 
-    # expect three RuntimeWarnings from numpy due to divides by zero
+    # expect three RuntimeWarnings from numpy due to division by zero
     assert len(warn_record) == 3
     for i in range(3):
         assert "divide by zero" in str(warn_record[i].message)


### PR DESCRIPTION
An infinite entry in a `matplotlib` bar plot seems to make all bars disappear when the `bottom` kwarg is used:

```python
import matplotlib.pyplot as plt
import numpy as np

unc = np.asarray([np.inf, 0.2])
plt.bar([1,2], 2*unc, bottom = 1-unc)
```

The plot works when replacing `np.inf` by some number, and without the `bottom` kwarg only the second bar is drawn (even with `np.inf` in the first entry of the array).

This behavior causes the MC uncertainty band in data/MC ratio panels to disappear if the model prediction in any bin is zero. To fix this, the ratio panel will now only be populated for bins where the model prediction is non-zero. In the remaining panels the content is ill-defined. This also adds a warning if the prediction in any bin is zero.

Thanks @Daniel-Noel for reporting this!

```
* only draw uncertainty band in data/MC ratio panel if model prediction is non-zero in bin
* added warning to data/MC plotting if model prediction in any bin is zero
```