### PR TITLE
feat: utility to match fit results to arbitrary model

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,7 +22,7 @@ repos:
     -   id: flake8
         additional_dependencies: [flake8-bugbear, flake8-import-order, flake8-print]
 -   repo: https://github.com/asottile/pyupgrade
-    rev: v2.28.1
+    rev: v2.29.0
     hooks:
     -   id: pyupgrade
         args: ["--py37-plus"]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,7 +22,7 @@ repos:
     -   id: flake8
         additional_dependencies: [flake8-bugbear, flake8-import-order, flake8-print]
 -   repo: https://github.com/asottile/pyupgrade
-    rev: v2.26.0
+    rev: v2.28.1
     hooks:
     -   id: pyupgrade
         args: ["--py37-plus"]

--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 [![CI status](https://github.com/scikit-hep/cabinetry/workflows/CI/badge.svg)](https://github.com/scikit-hep/cabinetry/actions?query=workflow%3ACI)
 [![Documentation Status](https://readthedocs.org/projects/cabinetry/badge/?version=latest)](https://cabinetry.readthedocs.io/en/latest/?badge=latest)
-[![codecov](https://codecov.io/gh/scikit-hep/cabinetry/branch/master/graph/badge.svg)](https://codecov.io/gh/scikit-hep/cabinetry)
+[![Codecov](https://codecov.io/gh/scikit-hep/cabinetry/branch/master/graph/badge.svg)](https://codecov.io/gh/scikit-hep/cabinetry)
 [![PyPI version](https://badge.fury.io/py/cabinetry.svg)](https://badge.fury.io/py/cabinetry)
-[![python version](https://img.shields.io/pypi/pyversions/cabinetry.svg)](https://pypi.org/project/cabinetry/)
+[![Python version](https://img.shields.io/pypi/pyversions/cabinetry.svg)](https://pypi.org/project/cabinetry/)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.4742752.svg)](https://doi.org/10.5281/zenodo.4742752)

--- a/src/cabinetry/model_utils.py
+++ b/src/cabinetry/model_utils.py
@@ -533,14 +533,14 @@ def match_fit_results(model: pyhf.pdf.Model, fit_results: FitResults) -> FitResu
     # re-build correlation matrix: start with diagonal matrix (assuming fit results do
     # not contain relevant info), and then insert values provided in fit results
     corr_mat = np.diagflat(np.ones_like(labels, dtype=float))
-    for i_target, i_prov in enumerate(indices_for_corr):
-        for j_target, j_prov in enumerate(indices_for_corr):
+    for i_target, i_orig in enumerate(indices_for_corr):
+        for j_target, j_orig in enumerate(indices_for_corr):
             # i_target and j_target are positions in matched correlation matrix
-            # i_prov and j_prov are positions in old matrix, None if missing from there
-            if i_prov is not None and j_prov is not None:
-                # if i_prov or j_prov are None, one of the parameters are not part of
+            # i_orig and j_orig are positions in old matrix, None if missing from there
+            if i_orig is not None and j_orig is not None:
+                # if i_orig or j_orig are None, one of the parameters are not part of
                 # original fit result, and no update to correlation matrix is needed
-                corr_mat[i_target][j_target] = fit_results.corr_mat[i_prov][j_prov]
+                corr_mat[i_target][j_target] = fit_results.corr_mat[i_orig][j_orig]
 
     fit_results_matched = FitResults(
         np.asarray(bestfit),

--- a/src/cabinetry/model_utils.py
+++ b/src/cabinetry/model_utils.py
@@ -269,7 +269,7 @@ def yield_stdev(
 
     labels = model.config.par_names()
     # continue with off-diagonal contributions if there are any
-    if np.count_nonzero(corr_mat - np.diag(np.ones_like(parameters))) > 0:
+    if np.count_nonzero(corr_mat - np.diagflat(np.ones_like(parameters))) > 0:
         # loop over pairs of parameters
         for i_par in range(model.config.npars):
             for j_par in range(model.config.npars):

--- a/src/cabinetry/model_utils.py
+++ b/src/cabinetry/model_utils.py
@@ -498,7 +498,8 @@ def match_fit_results(model: pyhf.pdf.Model, fit_results: FitResults) -> FitResu
     parameter settings for unconstrained parameters), and the associated uncertainties
     as given by ```prefit_uncertainties``` (zero uncertainty for unconstrained or fixed
     parameters). These parameters furthermore are assumed to have no correlation with
-    any other parameters.
+    any other parameters. If required, parameters are re-ordered to match the target
+    model.
 
     Args:
         model (pyhf.pdf.Model): model to match fit results to

--- a/src/cabinetry/model_utils.py
+++ b/src/cabinetry/model_utils.py
@@ -336,6 +336,8 @@ def prediction(
         ModelPrediction: model, yields and uncertainties per bin and channel
     """
     if fit_results is not None:
+        if fit_results.labels != model.config.par_names():
+            log.warning("parameter names in fit results and model do not match")
         # fit results specified, so they are used
         param_values = fit_results.bestfit
         param_uncertainty = fit_results.uncertainty

--- a/tests/test_model_utils.py
+++ b/tests/test_model_utils.py
@@ -239,11 +239,11 @@ def test_prediction(mock_asimov, mock_unc, mock_stdev, caplog, example_spec):
     )
     assert mock_stdev.call_args_list[0][1] == {}
 
-    # post-fit prediction and mis-match in parameter names
+    # post-fit prediction
     fit_results = FitResults(
         np.asarray([1.01, 1.1]),
         np.asarray([0.03, 0.1]),
-        [],
+        ["staterror_Signal-Region[0]", "Signal strength"],
         np.asarray([[1.0, 0.2], [0.2, 1.0]]),
         0.0,
     )
@@ -253,7 +253,7 @@ def test_prediction(mock_asimov, mock_unc, mock_stdev, caplog, example_spec):
     assert model_pred.total_stdev_model_bins == [[0.3]]  # from mock
     assert model_pred.total_stdev_model_channels == [0.3]  # from mock
     assert model_pred.label == "post-fit"
-    assert "parameter names in fit results and model do not match" in [
+    assert "parameter names in fit results and model do not match" not in [
         rec.message for rec in caplog.records
     ]
 
@@ -269,10 +269,21 @@ def test_prediction(mock_asimov, mock_unc, mock_stdev, caplog, example_spec):
         mock_stdev.call_args_list[1][0][3], np.asarray([[1.0, 0.2], [0.2, 1.0]])
     )
     assert mock_stdev.call_args_list[1][1] == {}
+
     caplog.clear()
 
-    # custom prediction label
-    model_pred = model_utils.prediction(model, label="abc")
+    # custom prediction label, mis-match in parameter names
+    fit_results = FitResults(
+        np.asarray([1.01, 1.1]),
+        np.asarray([0.03, 0.1]),
+        ["a", "b"],
+        np.asarray([[1.0, 0.2], [0.2, 1.0]]),
+        0.0,
+    )
+    model_pred = model_utils.prediction(model, fit_results=fit_results, label="abc")
+    assert "parameter names in fit results and model do not match" in [
+        rec.message for rec in caplog.records
+    ]
     assert model_pred.label == "abc"
     caplog.clear()
 

--- a/tests/test_model_utils.py
+++ b/tests/test_model_utils.py
@@ -164,7 +164,7 @@ def test_yield_stdev(example_spec, example_spec_multibin):
     # pre-fit
     parameters = np.asarray([1.0, 1.0])
     uncertainty = np.asarray([0.0495665682, 0.0])
-    diag_corr_mat = np.diag([1.0, 1.0])
+    diag_corr_mat = np.diagflat([1.0, 1.0])
     total_stdev_bin, total_stdev_chan = model_utils.yield_stdev(
         model, parameters, uncertainty, diag_corr_mat
     )


### PR DESCRIPTION
This adds a new API `model_utils.match_fit_results`, which takes a model and a fit result and then returns a modified fit result that matches the model as well as possible:
- re-ordering parameters if needed,
- removing parameters from fit result that are not in the target model,
- adding parameters that are in the model but not in the fit result.

When adding new parameters to the fit result, they are assumed to have their pre-fit values as given by `model_utils.asimov_parameters`, with associated uncertainty given by `model_utils.prefit_uncertainties`. They are furthermore assumed to not have any correlations with other parameters.

Additional minor changes:
- pre-commit updated
- changed `np.diag` (MATLAB-like API) to `np.diagflat`
- minor capitalization changes in readme
- added warning to `model_utils.prediction` if parameter names in fit results and model do not match

resolves #284

```
* added model_utils.match_fit_results function to match fit results to different model
* switched from use of np.diag to np.diagflat
* added warning to model_utils.prediction for mismatch of parameter names in fit results and model
* updated pre-commit 
```