### PR TITLE
feat: region- and sample-specific paths are optional for histogram inputs

### DIFF
--- a/src/cabinetry/schemas/config.json
+++ b/src/cabinetry/schemas/config.json
@@ -115,7 +115,7 @@
             "description": "a region of phase space",
             "$$description": [
                 "required: Name + Variable + Binning (for ntuple inputs),",
-                "Name + RegionPath (for histogram inputs)"
+                "Name (for histogram inputs)"
             ],
             "type": "object",
             "anyOf": [
@@ -123,7 +123,7 @@
                     "required": ["Name", "Variable", "Binning"]
                 },
                 {
-                    "required": ["Name", "RegionPath"]
+                    "required": ["Name"]
                 }
             ],
             "properties": {
@@ -162,7 +162,7 @@
             "description": "a sample of a specific process or data",
             "$$description": [
                 "required: Name + Tree (for ntuple inputs),",
-                "Name + SamplePath (for histogram inputs)"
+                "Name (for histogram inputs)"
             ],
             "type": "object",
             "anyOf": [
@@ -170,7 +170,7 @@
                     "required": ["Name", "Tree"]
                 },
                 {
-                    "required": ["Name", "SamplePath"]
+                    "required": ["Name"]
                 }
             ],
             "properties": {


### PR DESCRIPTION
This updates the config schema to make `RegionPath` and `SamplePath` optional for histogram inputs. #289 already introduced all the logic required to handle that scenario, but made the schema restrictive and required both these settings. While `SamplePath` is likely needed for most/all setups, `RegionPath` is not needed for single-distribution fits.

```
* made RegionPath and SamplePath settings optional for histogram inputs
```