### PR TITLE
feat: add pydocstyle to pre-commit and add missing docstrings

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,3 +32,7 @@ repos:
     -   id: check-added-large-files
         args: ["--maxkb=100"]
     -   id: trailing-whitespace
+-   repo: https://github.com/pycqa/pydocstyle
+    rev: 6.1.1
+    hooks:
+    -   id: pydocstyle

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -36,3 +36,4 @@ repos:
     rev: 6.1.1
     hooks:
     -   id: pydocstyle
+        args: ["--match=(?!setup|example).*\\.py'", "--match-dir='^(?!(tests|utils|docs)).*'", "--convention=google"]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -36,4 +36,5 @@ repos:
     rev: 6.1.1
     hooks:
     -   id: pydocstyle
+        # configuration duplicated in setup.cfg
         args: ["--match=(?!setup|example).*\\.py'", "--match-dir='^(?!(tests|utils|docs)).*'", "--convention=google"]

--- a/setup.cfg
+++ b/setup.cfg
@@ -71,6 +71,7 @@ per-file-ignores =
 inputs = src/cabinetry
 
 [pydocstyle]
+# configuration duplicated in pre-commit config
 match = (?!setup|example).*\.py
 match_dir = ^(?!(tests|utils|docs)).*
 convention = google

--- a/setup.cfg
+++ b/setup.cfg
@@ -69,3 +69,8 @@ per-file-ignores =
 
 [pytype]
 inputs = src/cabinetry
+
+[pydocstyle]
+match = (?!setup|example).*\.py
+match_dir = ^(?!(tests|utils|docs)).*
+convention = google

--- a/src/cabinetry/__init__.py
+++ b/src/cabinetry/__init__.py
@@ -1,3 +1,5 @@
+"""The cabinetry library."""
+
 import logging
 
 import cabinetry.configuration  # noqa: F401

--- a/src/cabinetry/cli/__init__.py
+++ b/src/cabinetry/cli/__init__.py
@@ -1,3 +1,5 @@
+"""Implements the command line interface."""
+
 import io
 import json
 import logging
@@ -19,6 +21,7 @@ class OrderedGroup(click.Group):
     """A group that shows commands in the order they were added."""
 
     def list_commands(self, _: Any) -> List[str]:
+        """Returns a list of commands."""
         return list(self.commands.keys())
 
 

--- a/src/cabinetry/configuration.py
+++ b/src/cabinetry/configuration.py
@@ -1,3 +1,5 @@
+"""Provides utilities to handle the cabinetry configuration."""
+
 import json
 import logging
 import pathlib

--- a/src/cabinetry/fit/results_containers.py
+++ b/src/cabinetry/fit/results_containers.py
@@ -1,3 +1,5 @@
+"""Provides containers for inference results."""
+
 from typing import List, NamedTuple
 
 import numpy as np

--- a/src/cabinetry/smooth.py
+++ b/src/cabinetry/smooth.py
@@ -1,3 +1,5 @@
+"""Implements histogram smoothing algorithms."""
+
 import logging
 import statistics
 from typing import List, TypeVar, Union

--- a/src/cabinetry/templates/utils.py
+++ b/src/cabinetry/templates/utils.py
@@ -1,4 +1,4 @@
-"""Contains utilities for template histogram handling."""
+"""Provides utilities for template histogram handling."""
 
 import pathlib
 from typing import Any, Dict, List, Optional, Union

--- a/src/cabinetry/visualize/utils.py
+++ b/src/cabinetry/visualize/utils.py
@@ -1,4 +1,4 @@
-"""Contains visualization utilities."""
+"""Provides visualization utilities."""
 
 import logging
 import pathlib


### PR DESCRIPTION
This adds `pydocstyle` to `pre-commit` and adds the last module-level docstrings that were still missing.

```
* added pydocstyle to pre-commit
* added remaining missing module-level docstrings
```