### PR TITLE
feat: add codespell to pre-commit and fix typos

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -43,4 +43,3 @@ repos:
     hooks:
     -   id: codespell
         args: ["-L", "hist", "src", "tests", "utils", "docs/*rst"]
-

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -38,3 +38,9 @@ repos:
     -   id: pydocstyle
         # configuration duplicated in setup.cfg
         args: ["--match=(?!setup|example).*\\.py'", "--match-dir='^(?!(tests|utils|docs)).*'", "--convention=google"]
+-   repo: https://github.com/codespell-project/codespell
+    rev: v2.1.0
+    hooks:
+    -   id: codespell
+        args: ["-L", "hist", "src", "tests", "utils", "docs/*rst"]
+

--- a/src/cabinetry/visualize/__init__.py
+++ b/src/cabinetry/visualize/__init__.py
@@ -315,7 +315,7 @@ def templates(
                 bins = nominal_histo.bins
                 # variable is a required config setting for ntuple inputs, but not for
                 # histogram inputs, so default to "observable" for these cases (the
-                # actual bin edges are preseved here, so not using "bin" as in data_mc)
+                # actual bin edges are preserved here, so not using "bin" as in data_mc)
                 variable = region.get("Variable", "observable")
                 nominal = {"yields": nominal_histo.yields, "stdev": nominal_histo.stdev}
 

--- a/tests/test_model_utils.py
+++ b/tests/test_model_utils.py
@@ -272,7 +272,7 @@ def test_prediction(mock_asimov, mock_unc, mock_stdev, caplog, example_spec):
 
     caplog.clear()
 
-    # custom prediction label, mis-match in parameter names
+    # custom prediction label, mismatch in parameter names
     fit_results = FitResults(
         np.asarray([1.01, 1.1]),
         np.asarray([0.03, 0.1]),

--- a/tests/test_route.py
+++ b/tests/test_route.py
@@ -143,7 +143,7 @@ def test_Router__find_match(processor_examples, caplog):
         is None
     )
 
-    # no matches available due to string mis-match
+    # no matches available due to string mismatch
     assert (
         example_router._find_match(
             example_router.template_builders, "reg", "background", "sys", "Up"

--- a/utils/create_ntuples.py
+++ b/utils/create_ntuples.py
@@ -156,7 +156,7 @@ def run(output_directory, *, visualize=False):
     yield_s = 125
     yield_b = 1000
     yield_b_var = 1000
-    labels = ["signal", "background", "background_varied"]  # names of prcesses
+    labels = ["signal", "background", "background_varied"]  # names of processes
     file_name = output_directory + "/prediction.root"
     file_name_pseudodata = output_directory + "/data.root"
 


### PR DESCRIPTION
Adding [`codespell`](https://github.com/codespell-project/codespell/), a spell-checker for code, to `pre-commit` so it runs automatically (including via CI). The tool flagged a few typos, which have been fixed.

```
* added codespell to pre-commit
* fixed spelling mistakes flagged by codespell
```