### PR TITLE
build: exclude root files from source distribution

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -10,4 +10,4 @@ include README.md
 include pyproject.toml
 include MANIFEST.in
 
-global-exclude __pycache__ *.py[cod] *.png
+global-exclude __pycache__ *.py[cod] *.png *.root


### PR DESCRIPTION
Updating `MANIFEST.in` to exclude `*.root` files from source distributions. Such files are for example produced from the ntuple / histogram creation scripts in `utils/`.

```
* excluded .root files from source distribution
```