### PR TITLE
chore: updating version to 0.4.0

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = cabinetry
-version = 0.3.0
+version = 0.4.0
 author = Alexander Held
 description = design and steer profile likelihood fits
 long_description = file: README.md

--- a/src/cabinetry/__init__.py
+++ b/src/cabinetry/__init__.py
@@ -13,7 +13,7 @@ import cabinetry.visualize  # noqa: F401
 import cabinetry.workspace  # noqa: F401
 
 
-__version__ = "0.3.0"
+__version__ = "0.4.0"
 
 
 def set_logging() -> None:


### PR DESCRIPTION
Updating to version 0.4.0. The new version introduces the handling of histogram inputs for workspace building and provides a new utility to match fit results to `pyhf` models. It also brings a couple of minor breaking API changes.

```
* updating version to 0.4.0
```