### PR TITLE
fix: update uproot version to ensure trees are readable by old ROOT versions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup
 
-extras_require = {"contrib": ["uproot>=4.1"]}  # uproot 4.1 for file writing
+extras_require = {"contrib": ["uproot>=4.1.4"]}  # file writing with TStreamerInfo
 extras_require["test"] = sorted(
     set(
         extras_require["contrib"]


### PR DESCRIPTION
`uproot` [4.1.4](https://github.com/scikit-hep/uproot4/releases/tag/4.1.4) added `TStreamerInfo` for `TTrees` written to files. This ensures that they can be read by older versions of ROOT as well. While this is not strictly needed for the purposes of `cabinetry` at the moment (ROOT file writing is only used to produce example inputs for demonstration purposes), it nevertheless seems good to update to this latest version. This will avoid possible complications when trying to open the files produced by `uproot` in another ROOT version (an older version, or possibly even a newer version in the future).

```
* updated uproot version to 4.1.4 to ensure trees are readable by old ROOT versions
```