### PR TITLE
fix: Use https protocol over unauthenticated git protocol

### DIFF
--- a/.github/workflows/dependencies-head.yml
+++ b/.github/workflows/dependencies-head.yml
@@ -26,7 +26,7 @@ jobs:
         python -m pip install --upgrade pip setuptools wheel
         python -m pip install --ignore-installed --upgrade -q --no-cache-dir -e .[test]
         python -m pip uninstall --yes pyhf
-        python -m pip install --upgrade --no-cache-dir git+git://github.com/scikit-hep/pyhf.git
+        python -m pip install --upgrade --no-cache-dir git+https://github.com/scikit-hep/pyhf.git
         python -m pip list
         sudo apt-get update
         sudo apt-get install ghostscript  # for pdf comparison
@@ -53,7 +53,7 @@ jobs:
         python -m pip install --upgrade pip setuptools wheel
         python -m pip install --ignore-installed --upgrade -q --no-cache-dir -e .[test]
         python -m pip uninstall --yes awkward
-        python -m pip install --upgrade --no-cache-dir git+git://github.com/scikit-hep/awkward-1.0.git
+        python -m pip install --upgrade --no-cache-dir git+https://github.com/scikit-hep/awkward-1.0.git
         python -m pip list
         sudo apt-get update
         sudo apt-get install ghostscript  # for pdf comparison
@@ -80,7 +80,7 @@ jobs:
         python -m pip install --upgrade pip setuptools wheel
         python -m pip install --ignore-installed --upgrade -q --no-cache-dir -e .[test]
         python -m pip uninstall --yes uproot
-        python -m pip install --upgrade --no-cache-dir git+git://github.com/scikit-hep/uproot4.git
+        python -m pip install --upgrade --no-cache-dir git+https://github.com/scikit-hep/uproot4.git
         python -m pip list
         sudo apt-get update
         sudo apt-get install ghostscript  # for pdf comparison
@@ -108,7 +108,7 @@ jobs:
         python -m pip install --ignore-installed --upgrade -q --no-cache-dir -e .[test]
         python -m pip uninstall --yes iminuit
         python -m pip install --upgrade --no-cache-dir cython
-        python -m pip install --upgrade --no-cache-dir git+git://github.com/scikit-hep/iminuit.git
+        python -m pip install --upgrade --no-cache-dir git+https://github.com/scikit-hep/iminuit.git
         python -m pip list
         sudo apt-get update
         sudo apt-get install ghostscript  # for pdf comparison
@@ -135,7 +135,7 @@ jobs:
         python -m pip install --upgrade pip setuptools wheel
         python -m pip install --ignore-installed --upgrade -q --no-cache-dir -e .[test]
         python -m pip uninstall --yes boost-histogram
-        python -m pip install --upgrade --no-cache-dir git+git://github.com/scikit-hep/boost-histogram.git
+        python -m pip install --upgrade --no-cache-dir git+https://github.com/scikit-hep/boost-histogram.git
         python -m pip list
         sudo apt-get update
         sudo apt-get install ghostscript  # for pdf comparison


### PR DESCRIPTION
# Description

Use of the unauthenticated git protocol (`git://`) is no longer supported on GitHub (c.f. the 2021-09-01 GitHub Security blog [Improving Git protocol security on GitHub](https://github.blog/2021-09-01-improving-git-protocol-security-github/)). As a result, the [current HEAD of dependencies workflow](https://github.com/scikit-hep/cabinetry/blob/b89bb09b97608e984864cde6d45f9b8901612a06/.github/workflows/dependencies-head.yml) fails with an error similar to that seen in https://github.com/scikit-hep/pyhf/pull/1680. 

e.g.

```
Collecting git+git://github.com/scikit-hep/uproot4.git
  Cloning git://github.com/scikit-hep/uproot4.git to /tmp/pip-req-build-6mgjtjoo
  Running command git clone --filter=blob:none -q git://github.com/scikit-hep/uproot4.git /tmp/pip-req-build-6mgjtjoo
  fatal: remote error:
    The unauthenticated git protocol on port 9418 is no longer supported.
  Please see https://github.blog/2021-09-01-improving-git-protocol-security-github/ for more information.
WARNING: Discarding git+git://github.com/scikit-hep/uproot4.git. Command errored out with exit status 128: git clone --filter=blob:none -q git://github.com/scikit-hep/uproot4.git /tmp/pip-req-build-6mgjtjoo Check the logs for full command output.
ERROR: Command errored out with exit status 128: git clone --filter=blob:none -q git://github.com/scikit-hep/uproot4.git /tmp/pip-req-build-6mgjtjoo Check the logs for full command output.
```


To avoid this, use the `https://` for cloning a Git repo.


```
* Use the https protocol to clone Git repositories over the
unauthenticated git protocol (git://) as it is no longer
supported on GitHub as of 2021-11-02.
   - c.f. https://github.blog/2021-09-01-improving-git-protocol-security-github/
```