### PR TITLE
feat: include MINOS uncertainties in fit results container

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 -   repo: https://github.com/psf/black
-    rev: 21.11b1
+    rev: 21.12b0
     hooks:
     -   id: black
 -   repo: https://github.com/pre-commit/mirrors-mypy

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 -   repo: https://github.com/psf/black
-    rev: 21.10b0
+    rev: 21.11b1
     hooks:
     -   id: black
 -   repo: https://github.com/pre-commit/mirrors-mypy
@@ -22,7 +22,7 @@ repos:
     -   id: flake8
         additional_dependencies: [flake8-bugbear, flake8-import-order, flake8-print]
 -   repo: https://github.com/asottile/pyupgrade
-    rev: v2.29.0
+    rev: v2.29.1
     hooks:
     -   id: pyupgrade
         args: ["--py37-plus"]

--- a/src/cabinetry/fit/results_containers.py
+++ b/src/cabinetry/fit/results_containers.py
@@ -1,6 +1,6 @@
 """Provides containers for inference results."""
 
-from typing import List, NamedTuple
+from typing import Dict, List, NamedTuple, Tuple
 
 import numpy as np
 
@@ -10,11 +10,14 @@ class FitResults(NamedTuple):
 
     Args:
         bestfit (np.ndarray): best-fit results of parameters
-        uncertainty (np.ndarray): uncertainties of best-fit parameter results
+        uncertainty (np.ndarray): uncertainties of best-fit parameter results, evaluated
+            with Hessian
         labels (List[str]): parameter labels
         corr_mat (np.ndarray): parameter correlation matrix
         best_twice_nll (float): -2 log(likelihood) at best-fit point
         goodess_of_fit (float, optional): goodness-of-fit p-value, defaults to -1
+        minos_uncertainty (Dict[str, Tuple[float, float]]): uncertainties of best-fit
+            parameter results indexed by parameter name, calculated with MINOS
     """
 
     bestfit: np.ndarray
@@ -23,6 +26,7 @@ class FitResults(NamedTuple):
     corr_mat: np.ndarray
     best_twice_nll: float
     goodness_of_fit: float = -1
+    minos_uncertainty: Dict[str, Tuple[float, float]] = {}
 
 
 class RankingResults(NamedTuple):

--- a/tests/fit/test_fit_results_containers.py
+++ b/tests/fit/test_fit_results_containers.py
@@ -18,6 +18,7 @@ def test_FitResults():
     assert np.allclose(fit_results.corr_mat, corr_mat)
     assert fit_results.best_twice_nll == best_twice_nll
     assert fit_results.goodness_of_fit == -1
+    assert fit_results.minos_uncertainty == {}
 
 
 def test_RankingResults():


### PR DESCRIPTION
This adds the lower/upper parameter uncertainties calculated with MINOS to the fit results container returned by MLE fits, in a new property called `minos_uncertainty`. While the symmetric uncertainties (calculated via the Hessian) are a list, the MINOS uncertainties are provided in a dict. This change in pattern is in line with how the MINOS uncertainties are calculated, requiring the parameter name(s) of the parameter(s) for which the algorithm is run in `fit.fit` (via the `minos` kwarg). If MINOS is not run, the dict is empty.

For the sake of keeping the results containers minimal and streamlined, a simple dict is used (as opposed to something like a `defaultdict`).

```
* MINOS parameter uncertainties are returned from fits via minos_uncertainty dict in FitResults container
* updated pre-commit
```

resolves #305