### PR TITLE
fix: ranking plot axis limits for impacts

### DIFF
--- a/src/cabinetry/visualize/plot_result.py
+++ b/src/cabinetry/visualize/plot_result.py
@@ -200,7 +200,7 @@ def ranking(
     ax_pulls.set_ylim([-1, num_pars])
 
     # impact axis limits: need largest pre-fit impact
-    impact_max = np.amax(np.abs(impact_prefit_up, impact_prefit_down))
+    impact_max = np.amax(np.fabs(np.hstack([impact_prefit_up, impact_prefit_down])))
     ax_impact.set_xlim([-impact_max * 1.1, impact_max * 1.1])
 
     # minor ticks

--- a/src/cabinetry/visualize/plot_result.py
+++ b/src/cabinetry/visualize/plot_result.py
@@ -200,7 +200,7 @@ def ranking(
     ax_pulls.set_ylim([-1, num_pars])
 
     # impact axis limits: need largest pre-fit impact
-    impact_max = np.amax(np.fabs(np.hstack([impact_prefit_up, impact_prefit_down])))
+    impact_max = np.amax(np.fabs(np.hstack((impact_prefit_up, impact_prefit_down))))
     ax_impact.set_xlim([-impact_max * 1.1, impact_max * 1.1])
 
     # minor ticks


### PR DESCRIPTION
The axis limit calculation for the impact axis in ranking plots only took impacts in up direction into account so far, accidentally overriding the array containing impacts in down direction instead of considering them too. Since the impacts had already been plotted when this happened, it does not affect the plotted values but only the axis limits. This fixes the bug and considers impacts in both up and down direction.

```
* take impacts in both up and down direction into account for the impact axis limits in ranking plots
```

resolves #308 