### PR TITLE
fix: channel splitting for multi-channel model predictions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@ repos:
     hooks:
     -   id: black
 -   repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.910-1
+    rev: v0.931
     hooks:
     -   id: mypy
         name: mypy with Python 3.7
@@ -22,12 +22,12 @@ repos:
     -   id: flake8
         additional_dependencies: [flake8-bugbear, flake8-import-order, flake8-print]
 -   repo: https://github.com/asottile/pyupgrade
-    rev: v2.29.1
+    rev: v2.31.0
     hooks:
     -   id: pyupgrade
         args: ["--py37-plus"]
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.0.1
+    rev: v4.1.0
     hooks:
     -   id: check-added-large-files
         args: ["--maxkb=100"]

--- a/src/cabinetry/model_utils.py
+++ b/src/cabinetry/model_utils.py
@@ -344,7 +344,7 @@ def prediction(
     # slice the yields into list of lists (of lists) where first index is channel,
     # second index is sample (and third index is bin)
     model_yields = [
-        yields_combined[model.config.channel_slices[ch]].tolist()
+        yields_combined[:, model.config.channel_slices[ch]].tolist()
         for ch in model.config.channels
     ]
 


### PR DESCRIPTION
#303 introduced a bug in `model_utils.prediction` when used with multi-channel models. The split of yields into channels was happening at the wrong depth after this refactor. This update fixes the bug, and changes the corresponding test to catch such an issue.

```
* fixed channel splitting for multi-channel model predictions
* updated pre-commit
```