### PR TITLE
feat: customizable confidence level for upper parameter limits

### DIFF
--- a/src/cabinetry/cli/__init__.py
+++ b/src/cabinetry/cli/__init__.py
@@ -236,7 +236,14 @@ def scan(
 @click.option(
     "--tolerance",
     default=0.01,
-    help="tolerance for convergence to CLs=0.05 (default: 0.01)",
+    help="tolerance for convergence to CLs=1-confidence_level (default: 0.01)",
+)
+@click.option(
+    "--confidence_level",
+    "--cl",
+    default=0.95,
+    type=click.FloatRange(0.0, 1.0, min_open=True, max_open=True),
+    help="confidence level for parameter limits (default: 0.95)",
 )
 @click.option(
     "--figfolder",
@@ -244,7 +251,11 @@ def scan(
     help='folder to save figures to (default: "figures")',
 )
 def limit(
-    ws_spec: io.TextIOWrapper, asimov: bool, tolerance: float, figfolder: str
+    ws_spec: io.TextIOWrapper,
+    asimov: bool,
+    tolerance: float,
+    confidence_level: float,
+    figfolder: str,
 ) -> None:
     """Calculates upper limits and visualizes CLs distribution.
 
@@ -253,7 +264,9 @@ def limit(
     _set_logging()
     ws = json.load(ws_spec)
     model, data = cabinetry_model_utils.model_and_data(ws, asimov=asimov)
-    limit_results = cabinetry_fit.limit(model, data, tolerance=tolerance)
+    limit_results = cabinetry_fit.limit(
+        model, data, tolerance=tolerance, confidence_level=confidence_level
+    )
     cabinetry_visualize.limit(limit_results, figure_folder=figfolder)
 
 

--- a/src/cabinetry/fit/__init__.py
+++ b/src/cabinetry/fit/__init__.py
@@ -729,7 +729,7 @@ def limit(
             poi_arr = np.fromiter(cache_CLs.keys(), dtype=float)
 
             # left: CLs has to be > cls_target, mask out values where CLs <= cls_target
-            masked_CLs_left = np.where(exp_CLs_next <= (cls_target), 1, exp_CLs_next)
+            masked_CLs_left = np.where(exp_CLs_next <= cls_target, 1, exp_CLs_next)
             if sum(masked_CLs_left != 1) == 0:
                 # all values are below cls_target, pick default lower bound
                 bracket_left = bracket_left_default

--- a/src/cabinetry/fit/__init__.py
+++ b/src/cabinetry/fit/__init__.py
@@ -579,10 +579,10 @@ def limit(
         bracket (Optional[Union[List[float], Tuple[float, float]]], optional): the two
             POI values used to start the observed limit determination, the limit must
             lie between these values and the values must not be the same, defaults to
-            None (then uses ``0.1`` as default lower value and the upper POI bound
+            None (then uses 0.1 as default lower value and the upper POI bound
             specified in the measurement as default upper value)
         tolerance (float, optional): tolerance in POI value for convergence to target
-            CLs value (``1-confidence_level``), defaults to 0.01
+            CLs value (1-``confidence_level``), defaults to 0.01
         maxiter (int, optional): maximum number of steps for limit finding, defaults to
             100
         confidence_level (float, optional): confidence level for calculation, defaults
@@ -630,7 +630,7 @@ def limit(
     ) -> float:
         """Root of this function is the POI value at the CLs=``cls_target`` crossing.
 
-        Returns ``1-cls_target`` for POI values below 0. Makes use of an external
+        Returns 1-``cls_target`` for POI values below 0. Makes use of an external
         cache to avoid re-fitting known POI values and to store all relevant values.
 
         Args:

--- a/src/cabinetry/fit/__init__.py
+++ b/src/cabinetry/fit/__init__.py
@@ -765,6 +765,7 @@ def limit(
         observed_CLs_np,
         expected_CLs_np,
         poi_arr,
+        confidence_level,
     )
     return limit_results
 

--- a/src/cabinetry/fit/__init__.py
+++ b/src/cabinetry/fit/__init__.py
@@ -596,8 +596,12 @@ def limit(
     """
     pyhf.set_backend(pyhf.tensorlib, pyhf.optimize.minuit_optimizer(verbose=1))
 
+    # show two decimals only if confidence level in percent is not an integer
+    cl_label = (
+        f"{confidence_level:.{0 if (confidence_level * 100).is_integer() else 2}%}"
+    )
     log.info(
-        f"calculating {confidence_level:.2%} confidence level upper limit for "
+        f"calculating {cl_label} confidence level upper limit for "
         f"{model.config.poi_name}"
     )
 
@@ -701,7 +705,7 @@ def limit(
             # invalid starting bracket is most common issue
             log.error(
                 f"CLs values at {bracket[0]:.4f} and {bracket[1]:.4f} do not bracket "
-                f"CLs={cls_target}, try a different starting bracket"
+                f"CLs={cls_target:.4f}, try a different starting bracket"
             )
             raise
 
@@ -748,7 +752,7 @@ def limit(
     log.info(f"total of {steps_total} steps to calculate all limits")
     if not all_converged:
         log.error("one or more calculations did not converge, check log")
-    log.info(f"summary of {confidence_level:.2%} confidence level upper limits:")
+    log.info(f"summary of {cl_label} confidence level upper limits:")
     for i_limit, limit_label in enumerate(limit_labels):
         log.info(f"{limit_label.ljust(17)}: {all_limits[i_limit]:.4f}")
 

--- a/src/cabinetry/fit/__init__.py
+++ b/src/cabinetry/fit/__init__.py
@@ -565,11 +565,13 @@ def limit(
     bracket: Optional[Union[List[float], Tuple[float, float]]] = None,
     tolerance: float = 0.01,
     maxiter: int = 100,
+    confidence_level: float = 0.95,
 ) -> LimitResults:
-    """Calculates observed and expected 95% confidence level upper parameter limits.
+    """Calculates observed and expected upper parameter limits.
 
     Limits are calculated for the parameter of interest (POI) defined in the model.
-    Brent's algorithm is used to automatically determine POI values to be tested.
+    Brent's algorithm is used to automatically determine POI values to be tested. The
+    desired confidence level can be configured, and defaults to 95%.
 
     Args:
         model (pyhf.pdf.Model): model to use in fits
@@ -579,10 +581,12 @@ def limit(
             lie between these values and the values must not be the same, defaults to
             None (then uses ``0.1`` as default lower value and the upper POI bound
             specified in the measurement as default upper value)
-        tolerance (float, optional): tolerance in POI value for convergence to CLs=0.05,
-            defaults to 0.01
+        tolerance (float, optional): tolerance in POI value for convergence to target
+            CLs value (``1-confidence_level``), defaults to 0.01
         maxiter (int, optional): maximum number of steps for limit finding, defaults to
             100
+        confidence_level (float, optional): confidence level for calculation, defaults
+            to 0.95 (95%)
 
     Raises:
         ValueError: if lower and upper bracket value are the same
@@ -592,7 +596,10 @@ def limit(
     """
     pyhf.set_backend(pyhf.tensorlib, pyhf.optimize.minuit_optimizer(verbose=1))
 
-    log.info(f"calculating upper limit for {model.config.poi_name}")
+    log.info(
+        f"calculating {confidence_level:.2%} confidence level upper limit for "
+        f"{model.config.poi_name}"
+    )
 
     # set lower POI bound to zero (for use with qmu_tilde)
     par_bounds = model.config.suggested_bounds()
@@ -613,32 +620,34 @@ def limit(
         poi: float,
         model: pyhf.pdf.Model,
         data: List[float],
+        cls_target: float,
         which_limit: int,
         limit_label: str,
     ) -> float:
-        """The root of this function is the POI value at the CLs=0.05 crossing.
+        """Root of this function is the POI value at the CLs=``cls_target`` crossing.
 
-        Returns 0.95 for POI values below 0. Makes use of an external cache to avoid
-        re-fitting with known POI values and to store all relevant values.
+        Returns ``1-cls_target`` for POI values below 0. Makes use of an external
+        cache to avoid re-fitting known POI values and to store all relevant values.
 
         Args:
             poi (float): value for parameter of interest
             model (pyhf.pdf.Model): model to use in fits
             data (List[float]): data (including auxdata) the model is fit to
+            cls_target (float): target CLs value to find by varying POI
             which_limit (int): which limit to run, 0: observed, 1: expected -2 sigma, 2:
                 expected -1 sigma, 3: expected, 4: expected +1 sigma, 5: expected +2
                 sigma
             limit_label (str): string to use when referring to the current limit
 
         Returns:
-            float: absolute value of difference to CLs=0.05
+            float: absolute value of difference to CLs=``cls_target``
         """
         if poi <= 0:
             # no fit needed for negative POI value, return a default value
             log.debug(
                 f"skipping fit for {model.config.poi_name} = {poi:.4f}, setting CLs = 1"
             )
-            return 0.95  # corresponds to distance of CLs = 1 to target CLs = 0.05
+            return 1 - cls_target  # distance of CLs = 1 to target CLs
         cache = cache_CLs.get(poi)
         if cache:
             observed, expected = cache  # use result from cache
@@ -660,10 +669,11 @@ def limit(
             f"{model.config.poi_name} = {poi:.4f}, {limit_label} CLs = "
             f"{current_CLs:.4f}{' (cached)' if cache else ''}"
         )
-        return current_CLs - 0.05
+        return current_CLs - cls_target
 
     # calculate all limits, one by one: observed, expected -2 sigma, expected -1 sigma,
     # expected, expected +1 sigma, expected +2 sigma
+    cls_target = 1 - confidence_level
     limit_labels = [
         "observed",
         "expected -2 sigma",
@@ -683,7 +693,7 @@ def limit(
             res = scipy.optimize.root_scalar(
                 _cls_minus_threshold,
                 bracket=bracket,
-                args=(model, data, i_limit, limit_label),
+                args=(model, data, cls_target, i_limit, limit_label),
                 method="brentq",
                 options={"xtol": tolerance, "maxiter": maxiter},
             )
@@ -691,7 +701,7 @@ def limit(
             # invalid starting bracket is most common issue
             log.error(
                 f"CLs values at {bracket[0]:.4f} and {bracket[1]:.4f} do not bracket "
-                "CLs=0.05, try a different starting bracket"
+                f"CLs={cls_target}, try a different starting bracket"
             )
             raise
 
@@ -714,22 +724,22 @@ def limit(
             # associated POI values
             poi_arr = np.fromiter(cache_CLs.keys(), dtype=float)
 
-            # left: CLs has to be > 0.05, mask out values where CLs <= 0.05
-            masked_CLs_left = np.where(exp_CLs_next <= 0.05, 1, exp_CLs_next)
+            # left: CLs has to be > cls_target, mask out values where CLs <= cls_target
+            masked_CLs_left = np.where(exp_CLs_next <= (cls_target), 1, exp_CLs_next)
             if sum(masked_CLs_left != 1) == 0:
-                # all values are below 0.05, pick default lower bound
+                # all values are below cls_target, pick default lower bound
                 bracket_left = bracket_left_default
             else:
-                # find closest to CLs = 0.05 from above
+                # find closest to CLs = cls_target from above
                 bracket_left = poi_arr[np.argmin(masked_CLs_left)]
 
-            # right: CLs has to be < 0.05, mask out values where CLs >= 0.05
-            masked_CLs_right = np.where(exp_CLs_next >= 0.05, -1, exp_CLs_next)
+            # right: CLs has to be < cls_target, mask out values where CLs >= cls_target
+            masked_CLs_right = np.where(exp_CLs_next >= cls_target, -1, exp_CLs_next)
             if sum(masked_CLs_right != -1) == 0:
-                # all values are above 0.05, pick default upper bound
+                # all values are above cls_target, pick default upper bound
                 bracket_right = bracket_right_default
             else:
-                # find closest to CLs=0.05 from below
+                # find closest to CLs=cls_target from below
                 bracket_right = poi_arr[np.argmax(masked_CLs_right)]
 
             bracket = (bracket_left, bracket_right)
@@ -738,7 +748,7 @@ def limit(
     log.info(f"total of {steps_total} steps to calculate all limits")
     if not all_converged:
         log.error("one or more calculations did not converge, check log")
-    log.info("summary of upper limits:")
+    log.info(f"summary of {confidence_level:.2%} confidence level upper limits:")
     for i_limit, limit_label in enumerate(limit_labels):
         log.info(f"{limit_label.ljust(17)}: {all_limits[i_limit]:.4f}")
 

--- a/src/cabinetry/fit/results_containers.py
+++ b/src/cabinetry/fit/results_containers.py
@@ -81,6 +81,7 @@ class LimitResults(NamedTuple):
         observed_CLs (np.ndarray): observed CLs values
         expected_CLs (np.ndarray): expected CLs values, including 1 and 2 sigma bands
         poi_values (np.ndarray): POI values used in scan
+        confidence_level (float): confidence level used for parameter limits
     """
 
     observed_limit: float
@@ -88,6 +89,7 @@ class LimitResults(NamedTuple):
     observed_CLs: np.ndarray
     expected_CLs: np.ndarray
     poi_values: np.ndarray
+    confidence_level: float
 
 
 class SignificanceResults(NamedTuple):

--- a/src/cabinetry/visualize/__init__.py
+++ b/src/cabinetry/visualize/__init__.py
@@ -604,6 +604,7 @@ def limit(
     limit_results: fit.LimitResults,
     *,
     figure_folder: Union[str, pathlib.Path] = "figures",
+    confidence_level: float = 0.95,
     close_figure: bool = True,
     save_figure: bool = True,
 ) -> mpl.figure.Figure:
@@ -613,6 +614,8 @@ def limit(
         limit_results (fit.LimitResults): results of upper limit determination
         figure_folder (Union[str, pathlib.Path], optional): path to the folder to save
             figures in, defaults to "figures"
+        confidence_level: (float, optional): confidence level to visualize via target
+            CLs value, defaults to 0.95 (95%)
         close_figure (bool, optional): whether to close figure, defaults to True
         save_figure (bool, optional): whether to save figure, defaults to True
 
@@ -626,6 +629,7 @@ def limit(
         limit_results.observed_CLs,
         limit_results.expected_CLs,
         limit_results.poi_values,
+        1 - confidence_level,
         figure_path=figure_path,
         close_figure=close_figure,
     )

--- a/src/cabinetry/visualize/__init__.py
+++ b/src/cabinetry/visualize/__init__.py
@@ -604,7 +604,6 @@ def limit(
     limit_results: fit.LimitResults,
     *,
     figure_folder: Union[str, pathlib.Path] = "figures",
-    confidence_level: float = 0.95,
     close_figure: bool = True,
     save_figure: bool = True,
 ) -> mpl.figure.Figure:
@@ -614,8 +613,6 @@ def limit(
         limit_results (fit.LimitResults): results of upper limit determination
         figure_folder (Union[str, pathlib.Path], optional): path to the folder to save
             figures in, defaults to "figures"
-        confidence_level: (float, optional): confidence level to visualize via target
-            CLs value, defaults to 0.95 (95%)
         close_figure (bool, optional): whether to close figure, defaults to True
         save_figure (bool, optional): whether to save figure, defaults to True
 
@@ -629,7 +626,7 @@ def limit(
         limit_results.observed_CLs,
         limit_results.expected_CLs,
         limit_results.poi_values,
-        1 - confidence_level,
+        1 - limit_results.confidence_level,
         figure_path=figure_path,
         close_figure=close_figure,
     )

--- a/src/cabinetry/visualize/plot_result.py
+++ b/src/cabinetry/visualize/plot_result.py
@@ -369,13 +369,14 @@ def limit(
     )
 
     # line through CLs = cls_target
+    cls_label = f"{cls_target:.{0 if (cls_target * 100).is_integer() else 2}%}"
     ax.hlines(
         cls_target,
         xmin=xmin,
         xmax=xmax,
         linestyle="dashdot",
         color="red",
-        label=f"CL$_S$ = {cls_target:.2%}",
+        label="CL$_S$ = " + cls_label,  # 2 decimals unless they are both 0, then 0
         zorder=1,  # draw beneath observed / expected
     )
 

--- a/src/cabinetry/visualize/plot_result.py
+++ b/src/cabinetry/visualize/plot_result.py
@@ -1,6 +1,7 @@
 """Visualizes inference results with matplotlib."""
 
 import logging
+import math
 import pathlib
 from typing import List, Optional, Union
 
@@ -368,8 +369,11 @@ def limit(
         zorder=0,  # draw beneath 1 sigma band
     )
 
+    # determine whether CLs value shown in percent is integer (float.is_integer() is not
+    # sufficient after calculation of 1-confidence_level in fit.limit)
+    cls_pct_is_integer = math.isclose(cls_target * 100, round(cls_target * 100))
+    cls_label = f"{cls_target:.{0 if cls_pct_is_integer else 2}%}"
     # line through CLs = cls_target
-    cls_label = f"{cls_target:.{0 if (cls_target * 100).is_integer() else 2}%}"
     ax.hlines(
         cls_target,
         xmin=xmin,

--- a/src/cabinetry/visualize/plot_result.py
+++ b/src/cabinetry/visualize/plot_result.py
@@ -317,6 +317,7 @@ def limit(
     observed_CLs: np.ndarray,
     expected_CLs: np.ndarray,
     poi_values: np.ndarray,
+    cls_target: float,
     *,
     figure_path: Optional[pathlib.Path] = None,
     close_figure: bool = False,
@@ -327,6 +328,7 @@ def limit(
         observed_CLs (np.ndarray): observed CLs values
         expected_CLs (np.ndarray): expected CLs values, including 1 and 2 sigma bands
         poi_values (np.ndarray): parameter of interest values used in scan
+        cls_target (float): target CLs value to visualize as horizontal line
         figure_path (Optional[pathlib.Path], optional): path where figure should be
             saved, or None to not save it, defaults to None
         close_figure (bool, optional): whether to close each figure immediately after
@@ -366,14 +368,14 @@ def limit(
         zorder=0,  # draw beneath 1 sigma band
     )
 
-    # line through CLs = 0.05
+    # line through CLs = cls_target
     ax.hlines(
-        0.05,
+        cls_target,
         xmin=xmin,
         xmax=xmax,
         linestyle="dashdot",
         color="red",
-        label=r"CL$_S$ = 5%",
+        label=f"CL$_S$ = {cls_target:.2%}",
         zorder=1,  # draw beneath observed / expected
     )
 

--- a/tests/fit/test_fit.py
+++ b/tests/fit/test_fit.py
@@ -501,6 +501,7 @@ def test_limit(example_spec_with_background, caplog):
     assert np.allclose(limit_results.observed_CLs[-1], 0.0)
     assert np.allclose(limit_results.expected_CLs[-1], [0.0, 0.0, 0.0, 0.0, 0.0])
     assert np.allclose(limit_results.poi_values[-1], 8.0)  # from custom POI range
+    assert limit_results.confidence_level == 0.95
     # verify that POI values are sorted
     assert np.allclose(limit_results.poi_values, sorted(limit_results.poi_values))
     caplog.clear()
@@ -531,15 +532,15 @@ def test_limit(example_spec_with_background, caplog):
     assert np.allclose(limit_results.expected_limit, expected_limit, rtol=2e-2)
     caplog.clear()
 
-    # bracket does not contain root
+    # bracket does not contain root, custom confidence level
     with pytest.raises(
         ValueError, match=re.escape("f(a) and f(b) must have different signs")
     ):
-        fit.limit(model, data, bracket=(1.0, 2.0))
-        assert (
-            "CLs values at 1.000 and 2.000 do not bracket CLs=0.05, try a different "
-            "starting bracket" in [rec.message for rec in caplog.records]
-        )
+        fit.limit(model, data, bracket=(1.0, 2.0), confidence_level=0.9)
+    assert (
+        "CLs values at 1.0000 and 2.0000 do not bracket CLs=0.1000, try a different "
+        "starting bracket" in [rec.message for rec in caplog.records]
+    )
     caplog.clear()
 
     # bracket with identical values

--- a/tests/fit/test_fit_results_containers.py
+++ b/tests/fit/test_fit_results_containers.py
@@ -63,14 +63,21 @@ def test_LimitResults():
     observed_CLs = np.asarray([0.05])
     expected_CLs = np.asarray([0.01, 0.02, 0.05, 0.07, 0.10])
     poi_values = np.asarray([3.0])
+    confidence_level = 0.90
     limit_results = fit.LimitResults(
-        observed_limit, expected_limit, observed_CLs, expected_CLs, poi_values
+        observed_limit,
+        expected_limit,
+        observed_CLs,
+        expected_CLs,
+        poi_values,
+        confidence_level,
     )
     assert limit_results.observed_limit == observed_limit
     assert np.allclose(limit_results.expected_limit, expected_limit)
     assert np.allclose(limit_results.observed_CLs, observed_CLs)
     assert np.allclose(limit_results.expected_CLs, expected_CLs)
     assert np.allclose(limit_results.poi_values, poi_values)
+    assert np.allclose(limit_results.confidence_level, confidence_level)
 
 
 def test_SignificanceResults():

--- a/tests/visualize/test_visualize.py
+++ b/tests/visualize/test_visualize.py
@@ -567,8 +567,9 @@ def test_limit(mock_draw):
     observed_CLs = np.asarray([0.75, 0.32, 0.02])
     expected_CLs = np.asarray([[0.1, 0.2, 0.3, 0.4, 0.5] for _ in range(3)])
     poi_values = np.asarray([0, 1, 2])
+    confidence_level = 0.90
     limit_results = fit.LimitResults(
-        3.0, np.empty(5), observed_CLs, expected_CLs, poi_values
+        3.0, np.empty(5), observed_CLs, expected_CLs, poi_values, confidence_level
     )
 
     fig = visualize.limit(limit_results, figure_folder=folder_path)
@@ -578,6 +579,7 @@ def test_limit(mock_draw):
     assert np.allclose(mock_draw.call_args[0][0], limit_results.observed_CLs)
     assert np.allclose(mock_draw.call_args[0][1], limit_results.expected_CLs)
     assert np.allclose(mock_draw.call_args[0][2], limit_results.poi_values)
+    assert np.allclose(mock_draw.call_args[0][3], 1 - limit_results.confidence_level)
     assert mock_draw.call_args[1] == {"figure_path": figure_path, "close_figure": True}
 
     # do not close figure, do not save figure

--- a/tests/visualize/test_visualize_plot_result.py
+++ b/tests/visualize/test_visualize_plot_result.py
@@ -153,8 +153,11 @@ def test_limit(tmp_path):
         ]
     )
     poi_values = np.asarray([0.5, 1.0, 1.5, 2.0])
+    cls_target = 0.05
 
-    fig = plot_result.limit(observed_CLs, expected_CLs, poi_values, figure_path=fname)
+    fig = plot_result.limit(
+        observed_CLs, expected_CLs, poi_values, cls_target, figure_path=fname
+    )
     assert compare_images("tests/visualize/reference/limit.png", str(fname), 0) is None
 
     # compare figure returned by function
@@ -165,7 +168,7 @@ def test_limit(tmp_path):
     # do not save figure, but close it
     with mock.patch("cabinetry.visualize.utils._save_and_close") as mock_close_safe:
         fig = plot_result.limit(
-            observed_CLs, expected_CLs, poi_values, close_figure=True
+            observed_CLs, expected_CLs, poi_values, cls_target, close_figure=True
         )
         assert mock_close_safe.call_args_list == [((fig, None, True), {})]
 


### PR DESCRIPTION
The confidence level for upper parameter limit determination was previously hardcoded to 95%. It is now customizable in `fit.limit` via a new `confidence_level` keyword argument, and in the `cabinetry limit` CLI via `--cl` or `--confidence_level`. The confidence level is added to the `LimitResults` container, and the visualization via `visualize.limit` uses the value from the container when drawing the horizontal line visualizing the target CLs value.

```
* added confidence_level keyword argument to fit.limit to configure desired confidence level
* LimitResults container now contains confidence level in confidence_level property
* added configurable confidence level to command-line interface for parameter limits
```