### PR TITLE
perf: vectorize yield uncertainty calculation

### DIFF
--- a/src/cabinetry/model_utils.py
+++ b/src/cabinetry/model_utils.py
@@ -302,6 +302,10 @@ def yield_stdev(
         v_times_m_times_v = sym_uncs[:, np.newaxis, ...] * m_times_v
         # finally perform sums over i and j, remaining indices: channel, bin
         # ak.flatten due to https://github.com/scikit-hep/awkward-1.0/issues/1283
+        assert v_times_m_times_v.ndim == 4, (
+            "unexpected dimensionality of array, please report if you run into this: "
+            "https://github.com/scikit-hep/cabinetry/issues/326"
+        )
         total_variance = np.sum(ak.flatten(v_times_m_times_v, axis=1), axis=0)
 
     # convert to standard deviations per bin and per channel


### PR DESCRIPTION
This vectorizes the previously loop-based calculations when determining yield uncertainties. Thanks a lot to @agoose77 for the invaluable help!

For a moderately complex workspace with roughly 20 samples in 50 bins and 200 (non-expanded) parameters, the runtime of the diagonal contributions goes from 0.7 s to below 0.01 s (including setting up an array that is re-used for off-diagonal terms). The off-diagonal contribution goes from 180 s to 0.4 s.

After these changes, the bottleneck in `yield_stdev` is now the initial setup of the yields for all variations (4 s in the above example). There is probably some room to optimize this a bit further as well (example in https://github.com/scikit-hep/cabinetry/issues/315#issuecomment-1033705658). This topic will be tracked in #325.

The vectorization of the off-diagonal contribution does not take advantage of two things that were previously used: the symmetry of the correlation matrix, and the fact that `staterror` modifiers are orthogonal in their yield effects on bins (but not on channels, see #323). Given the performance improvement, this may not be crucial anymore, but perhaps there is a way to also take advantage of that in the future.

The implementation uses `ak.flatten` to sum over one dimension due to https://github.com/scikit-hep/awkward-1.0/issues/1283. The subsequent summation with a three-dimensional array works fine. There is an `assert` in the implementation to ensure we are not affected by the upstream bug, and after an upstream fix this can be changed in `cabinetry`. This is tracked via #326.

resolves #315

```
* vectorized calculation of yield uncertainties
* speedup is two orders of magnitude for moderately complex model
```