### PR TITLE
style: apply black 22.1 formatting

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 -   repo: https://github.com/psf/black
-    rev: 21.12b0
+    rev: 22.1.0
     hooks:
     -   id: black
 -   repo: https://github.com/pre-commit/mirrors-mypy

--- a/src/cabinetry/histo.py
+++ b/src/cabinetry/histo.py
@@ -57,7 +57,7 @@ class Histogram(bh.Histogram, family=cabinetry):
         )
         yields = np.asarray(yields)
         stdev = np.asarray(stdev)
-        out[...] = np.stack([yields, stdev ** 2], axis=-1)
+        out[...] = np.stack([yields, stdev**2], axis=-1)
         return out
 
     @classmethod
@@ -162,7 +162,7 @@ class Histogram(bh.Histogram, family=cabinetry):
         Args:
             value (np.ndarray): the standard deviation
         """
-        self.view().variance = value ** 2  # type: ignore
+        self.view().variance = value**2  # type: ignore
 
     @property
     def bins(self) -> np.ndarray:

--- a/src/cabinetry/model_utils.py
+++ b/src/cabinetry/model_utils.py
@@ -248,7 +248,7 @@ def yield_stdev(
     # first do the diagonal of the correlation matrix
     for i_par in range(model.config.npars):
         symmetric_unc = (up_variations_ak[i_par] - down_variations_ak[i_par]) / 2
-        total_variance = total_variance + symmetric_unc ** 2
+        total_variance = total_variance + symmetric_unc**2
 
     labels = model.config.par_names()
     # continue with off-diagonal contributions if there are any

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,7 +13,7 @@ class Utils:
     @staticmethod
     def create_histogram(fname, histname, bins, yields, stdev):
         hist = bh.Histogram(bh.axis.Variable(bins), storage=bh.storage.Weight())
-        hist[...] = np.stack([yields, stdev ** 2], axis=-1)
+        hist[...] = np.stack([yields, stdev**2], axis=-1)
         with uproot.recreate(fname) as f:
             f[histname] = hist
 

--- a/tests/templates/test_templates_builder.py
+++ b/tests/templates/test_templates_builder.py
@@ -18,46 +18,34 @@ def test__ntuple_paths(caplog):
     ]
 
     # general path with region and sample templates
-    assert (
-        builder._ntuple_paths(
-            "{RegionPath}/{SamplePath}",
-            {"RegionPath": "region"},
-            {"SamplePath": "sample.root"},
-            {},
-            None,
-        )
-        == [pathlib.Path("region/sample.root")]
-    )
+    assert builder._ntuple_paths(
+        "{RegionPath}/{SamplePath}",
+        {"RegionPath": "region"},
+        {"SamplePath": "sample.root"},
+        {},
+        None,
+    ) == [pathlib.Path("region/sample.root")]
 
     # SamplePath with list of two samples
-    assert (
-        builder._ntuple_paths(
-            "{RegionPath}/{SamplePath}",
-            {"RegionPath": "region"},
-            {"SamplePath": ["sample.root", "new.root"]},
-            {},
-            None,
-        )
-        == [pathlib.Path("region/sample.root"), pathlib.Path("region/new.root")]
-    )
+    assert builder._ntuple_paths(
+        "{RegionPath}/{SamplePath}",
+        {"RegionPath": "region"},
+        {"SamplePath": ["sample.root", "new.root"]},
+        {},
+        None,
+    ) == [pathlib.Path("region/sample.root"), pathlib.Path("region/new.root")]
 
     # systematic with override for RegionPath and SamplePath
-    assert (
-        builder._ntuple_paths(
-            "{RegionPath}/{SamplePath}",
-            {"RegionPath": "reg_1"},
-            {"SamplePath": "path.root"},
-            {
-                "Name": "variation",
-                "Up": {
-                    "SamplePath": ["variation.root", "new.root"],
-                    "RegionPath": "reg_2",
-                },
-            },
-            "Up",
-        )
-        == [pathlib.Path("reg_2/variation.root"), pathlib.Path("reg_2/new.root")]
-    )
+    assert builder._ntuple_paths(
+        "{RegionPath}/{SamplePath}",
+        {"RegionPath": "reg_1"},
+        {"SamplePath": "path.root"},
+        {
+            "Name": "variation",
+            "Up": {"SamplePath": ["variation.root", "new.root"], "RegionPath": "reg_2"},
+        },
+        "Up",
+    ) == [pathlib.Path("reg_2/variation.root"), pathlib.Path("reg_2/new.root")]
 
     # systematic without override
     assert builder._ntuple_paths(

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -271,8 +271,7 @@ def test_histogram_reading(tmp_path, histogram_creator):
     # override config options to point to tmp_path
     cabinetry_config["General"]["HistogramFolder"] = str(tmp_path / "histograms")
     cabinetry_config["General"]["InputPath"] = (
-        f"{tmp_path / 'histograms.root'}:"
-        f"{{RegionPath}}/{{SamplePath}}/{{VariationPath}}"
+        f"{tmp_path / 'histograms.root'}:" "{RegionPath}/{SamplePath}/{VariationPath}"
     )
 
     cabinetry.templates.collect(cabinetry_config, method="uproot")

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -271,7 +271,7 @@ def test_histogram_reading(tmp_path, histogram_creator):
     # override config options to point to tmp_path
     cabinetry_config["General"]["HistogramFolder"] = str(tmp_path / "histograms")
     cabinetry_config["General"]["InputPath"] = (
-        f"{tmp_path / 'histograms.root'}:" "{RegionPath}/{SamplePath}/{VariationPath}"
+        f"{tmp_path / 'histograms.root'}:" + "{RegionPath}/{SamplePath}/{VariationPath}"
     )
 
     cabinetry.templates.collect(cabinetry_config, method="uproot")

--- a/tests/test_route.py
+++ b/tests/test_route.py
@@ -18,7 +18,7 @@ class ProcessorExamples:
             hist = bh.Histogram(bh.axis.Variable([0, 1]), storage=bh.storage.Weight())
             yields = np.asarray([2])
             stdev = np.asarray([0.1])
-            hist[...] = np.stack([yields, stdev ** 2], axis=-1)
+            hist[...] = np.stack([yields, stdev**2], axis=-1)
             return hist
 
         return example_template_builder

--- a/utils/create_histograms.py
+++ b/utils/create_histograms.py
@@ -13,32 +13,32 @@ def run(output_directory):
     with uproot.recreate(file_name) as f:
         yields = np.asarray([112.0, 112.0, 124.0, 66.0])
         stdev = np.asarray([10.58300524, 10.58300524, 11.13552873, 8.1240384])
-        hist[...] = np.stack([yields, stdev ** 2], axis=-1)
+        hist[...] = np.stack([yields, stdev**2], axis=-1)
         f["SR/Data/Nominal"] = hist
 
         yields = np.asarray([0.0, 1.58536913, 23.6164268, 24.54892223])
         stdev = np.asarray([0.0, 0.19931166, 0.77410713, 0.78830503])
-        hist[...] = np.stack([yields, stdev ** 2], axis=-1)
+        hist[...] = np.stack([yields, stdev**2], axis=-1)
         f["SR/Signal/Nominal"] = hist
 
         yields = np.asarray([112.73896936, 128.62169539, 88.10700838, 55.24607072])
         stdev = np.asarray([4.76136678, 5.10645036, 4.21104367, 3.34933335])
-        hist[...] = np.stack([yields, stdev ** 2], axis=-1)
+        hist[...] = np.stack([yields, stdev**2], axis=-1)
         f["SR/Background/Nominal"] = hist
 
         yields = np.asarray([53.85246451, 85.0382603, 90.75880537, 78.14459379])
         stdev = np.asarray([3.29419354, 4.14450981, 4.27730978, 3.96701472])
-        hist[...] = np.stack([yields, stdev ** 2], axis=-1)
+        hist[...] = np.stack([yields, stdev**2], axis=-1)
         f["SR/Background/Modeling_Up"] = hist
 
         yields = np.asarray([98.13569365, 154.1222757, 135.20449815, 103.14744392])
         stdev = np.asarray([4.17025569, 6.14088444, 6.47920695, 6.2581315])
-        hist[...] = np.stack([yields, stdev ** 2], axis=-1)
+        hist[...] = np.stack([yields, stdev**2], axis=-1)
         f["SR/Background/WeightBasedModeling_Up"] = hist
 
         yields = np.asarray([78.91727855, 90.03518677, 61.67490587, 38.6722495])
         stdev = np.asarray([3.33295675, 3.57451525, 2.94773057, 2.34453334])
-        hist[...] = np.stack([yields, stdev ** 2], axis=-1)
+        hist[...] = np.stack([yields, stdev**2], axis=-1)
         f["SR/Background/WeightBasedModeling_Down"] = hist
 
 


### PR DESCRIPTION
The [first non-beta release of `black`, `22.1.0`](https://black.readthedocs.io/en/stable/change_log.html) introduced some small formatting changes. This updates the code to the latest version of `black`.

```
* apply formatting changes introduced by black 22.1.0
* updated pre-commit
```