### PR TITLE
test: relax yield uncertainty tolerance in integration test

### DIFF
--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -173,7 +173,7 @@ def test_integration(tmp_path, ntuple_creator, caplog):
         [[11.898333, 7.283185, 7.414715, 7.687922]],
         rtol=1e-4,
     )
-    assert np.allclose(model_postfit.total_stdev_model_channels, [20.329523])
+    assert np.allclose(model_postfit.total_stdev_model_channels, [20.329756], atol=1e-4)
     _ = cabinetry.visualize.data_mc(model_postfit, data, close_figure=True)
 
     # nuisance parameter ranking


### PR DESCRIPTION
Slightly relax the tolerance for yield uncertainty in an integration test. The previous default was slightly larger than the differences between two local setups. The new absolute tolerance is much smaller than what would usually be a physically significant difference.

```
* slightly relax tolerance in comparison of yield uncertainties in integration test
```