### PR TITLE
test: increase log level for matplotlib in tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,20 @@
+import logging.config
+
 import boost_histogram as bh
 import numpy as np
 import pytest
 import uproot
+
+
+def pytest_sessionstart():
+    # suppress verbose DEBUG level output from matplotlib when tests fail
+    logging.config.dictConfig(
+        {
+            "loggers": {"matplotlib": {"level": "INFO"}},
+            "disable_existing_loggers": False,
+            "version": 1,
+        }
+    )
 
 
 class Utils:


### PR DESCRIPTION
When tests fail, the captured log calls sometimes contain a lot of `DEBUG` level output from `matplotlib.font_manager`. This modifies the logging configuration in tests such that the minimum level for `matplotlib` log output is now `INFO`. The implementation is adopted from https://stackoverflow.com/a/66925665.

```
* set log level of matplotlib in tests to INFO
```