### PR TITLE
feat: parameter customization for general inference

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -55,7 +55,7 @@ filterwarnings =
     ignore:no code associated:UserWarning:typeguard:
 
 [flake8]
-max-complexity = 15
+max-complexity = 16
 max-line-length = 88
 exclude = docs/conf.py
 count = True

--- a/src/cabinetry/fit/__init__.py
+++ b/src/cabinetry/fit/__init__.py
@@ -815,7 +815,14 @@ def limit(
     return limit_results
 
 
-def significance(model: pyhf.pdf.Model, data: List[float]) -> SignificanceResults:
+def significance(
+    model: pyhf.pdf.Model,
+    data: List[float],
+    *,
+    init_pars: Optional[List[float]] = None,
+    fix_pars: Optional[List[bool]] = None,
+    par_bounds: Optional[List[Tuple[float, float]]] = None,
+) -> SignificanceResults:
     """Calculates the discovery significance of a positive signal.
 
     Observed and expected p-values and significances are both calculated and reported.
@@ -823,6 +830,12 @@ def significance(model: pyhf.pdf.Model, data: List[float]) -> SignificanceResult
     Args:
         model (pyhf.pdf.Model): model to use in fits
         data (List[float]): data (including auxdata) the model is fit to
+        init_pars (Optional[List[float]], optional): list of initial parameter settings,
+            defaults to None (use ``pyhf`` suggested inits)
+        fix_pars (Optional[List[bool]], optional): list of booleans specifying which
+            parameters are held constant, defaults to None (use ``pyhf`` suggestion)
+        par_bounds (Optional[List[Tuple[float, float]]], optional): list of tuples with
+            parameter bounds for fit, defaults to None (use ``pyhf`` suggested bounds)
 
     Returns:
         SignificanceResults: observed and expected p-values and significances
@@ -831,7 +844,14 @@ def significance(model: pyhf.pdf.Model, data: List[float]) -> SignificanceResult
 
     log.info("calculating discovery significance")
     obs_p_val, exp_p_val = pyhf.infer.hypotest(
-        0.0, data, model, test_stat="q0", return_expected=True
+        0.0,
+        data,
+        model,
+        init_pars=init_pars,
+        fixed_params=fix_pars,
+        par_bounds=par_bounds,
+        test_stat="q0",
+        return_expected=True,
     )
     obs_p_val = float(obs_p_val)
     exp_p_val = float(exp_p_val)

--- a/src/cabinetry/fit/__init__.py
+++ b/src/cabinetry/fit/__init__.py
@@ -607,6 +607,9 @@ def limit(
     tolerance: float = 0.01,
     maxiter: int = 100,
     confidence_level: float = 0.95,
+    init_pars: Optional[List[float]] = None,
+    fix_pars: Optional[List[bool]] = None,
+    par_bounds: Optional[List[Tuple[float, float]]] = None,
 ) -> LimitResults:
     """Calculates observed and expected upper parameter limits.
 
@@ -628,6 +631,12 @@ def limit(
             100
         confidence_level (float, optional): confidence level for calculation, defaults
             to 0.95 (95%)
+        init_pars (Optional[List[float]], optional): list of initial parameter settings,
+            defaults to None (use ``pyhf`` suggested inits)
+        fix_pars (Optional[List[bool]], optional): list of booleans specifying which
+            parameters are held constant, defaults to None (use ``pyhf`` suggestion)
+        par_bounds (Optional[List[Tuple[float, float]]], optional): list of tuples with
+            parameter bounds for fit, defaults to None (use ``pyhf`` suggested bounds)
 
     Raises:
         ValueError: if lower and upper bracket value are the same
@@ -646,8 +655,9 @@ def limit(
         f"{model.config.poi_name}"
     )
 
+    # use par_bounds provided in function argument if they exist, else use default
+    par_bounds = par_bounds or model.config.suggested_bounds()
     # set lower POI bound to zero (for use with qmu_tilde)
-    par_bounds = model.config.suggested_bounds()
     par_bounds[model.config.poi_index] = [0, par_bounds[model.config.poi_index][1]]
     log.debug("setting lower parameter bound for POI to 0")
 
@@ -702,9 +712,11 @@ def limit(
                 poi,
                 data,
                 model,
+                init_pars=init_pars,
+                fixed_params=fix_pars,
+                par_bounds=par_bounds,
                 test_stat="qtilde",
                 return_expected_set=True,
-                par_bounds=par_bounds,
             )
             observed = float(results[0])  # 1 value per scan point
             expected = np.asarray(results[1])  # 5 per point (with 1 and 2 sigma bands)

--- a/src/cabinetry/fit/__init__.py
+++ b/src/cabinetry/fit/__init__.py
@@ -657,9 +657,13 @@ def limit(
 
     # use par_bounds provided in function argument if they exist, else use default
     par_bounds = par_bounds or model.config.suggested_bounds()
-    # set lower POI bound to zero (for use with qmu_tilde)
-    par_bounds[model.config.poi_index] = (0.0, par_bounds[model.config.poi_index][1])
-    log.debug("setting lower parameter bound for POI to 0")
+    if par_bounds[model.config.poi_index][0] < 0:
+        # set lower POI bound to zero (for use with qmu_tilde)
+        par_bounds[model.config.poi_index] = (
+            0.0,
+            par_bounds[model.config.poi_index][1],
+        )
+        log.debug("setting lower parameter bound for POI to 0")
 
     # set default bracket to (0.1, upper POI bound in measurement) if needed
     bracket_left_default = 0.1

--- a/src/cabinetry/fit/__init__.py
+++ b/src/cabinetry/fit/__init__.py
@@ -658,7 +658,7 @@ def limit(
     # use par_bounds provided in function argument if they exist, else use default
     par_bounds = par_bounds or model.config.suggested_bounds()
     # set lower POI bound to zero (for use with qmu_tilde)
-    par_bounds[model.config.poi_index] = [0, par_bounds[model.config.poi_index][1]]
+    par_bounds[model.config.poi_index] = (0.0, par_bounds[model.config.poi_index][1])
     log.debug("setting lower parameter bound for POI to 0")
 
     # set default bracket to (0.1, upper POI bound in measurement) if needed

--- a/tests/fit/test_fit.py
+++ b/tests/fit/test_fit.py
@@ -431,6 +431,7 @@ def test_ranking(mock_fit, example_spec):
             mock_fit.call_args_list[i][1]["init_pars"], expected_inits[i]
         )
         assert np.allclose(mock_fit.call_args_list[i][1]["fix_pars"], expected_fix)
+        assert mock_fit.call_args_list[i][1]["par_bounds"] is None
         assert mock_fit.call_args_list[i][1]["custom_fit"] is False
 
     # POI removed from fit results
@@ -457,19 +458,36 @@ def test_ranking(mock_fit, example_spec):
     assert np.allclose(ranking_results.postfit_up, [0.2])
     assert np.allclose(ranking_results.postfit_down, [-0.2])
 
-    # no reference results
-    ranking_results = fit.ranking(model, data, custom_fit=True)
+    # no reference results, init/fixed pars, par bounds
+    ranking_results = fit.ranking(
+        model,
+        data,
+        init_pars=[1.0, 1.5],
+        fix_pars=[False, False],
+        par_bounds=[(0.1, 10), (0, 5)],
+        custom_fit=True,
+    )
     assert mock_fit.call_count == 9
     # reference fit
-    assert mock_fit.call_args_list[-3] == ((model, data), {"custom_fit": True})
+    assert mock_fit.call_args_list[-3] == (
+        (model, data),
+        {
+            "init_pars": [1.0, 1.5],
+            "fix_pars": [False, False],
+            "par_bounds": [(0.1, 10), (0, 5)],
+            "custom_fit": True,
+        },
+    )
     # fits for impact
     assert mock_fit.call_args_list[-2][0] == (model, data)
-    assert np.allclose(mock_fit.call_args_list[-2][1]["init_pars"], [1.2, 1.0])
+    assert np.allclose(mock_fit.call_args_list[-2][1]["init_pars"], [1.2, 1.5])
     assert mock_fit.call_args_list[-2][1]["fix_pars"] == [True, False]
+    assert mock_fit.call_args_list[-2][1]["par_bounds"] == [(0.1, 10), (0, 5)]
     assert mock_fit.call_args_list[-2][1]["custom_fit"] is True
     assert mock_fit.call_args_list[-1][0] == (model, data)
-    assert np.allclose(mock_fit.call_args_list[-1][1]["init_pars"], [0.6, 1.0])
+    assert np.allclose(mock_fit.call_args_list[-1][1]["init_pars"], [0.6, 1.5])
     assert mock_fit.call_args_list[-1][1]["fix_pars"] == [True, False]
+    assert mock_fit.call_args_list[-1][1]["par_bounds"] == [(0.1, 10), (0, 5)]
     assert mock_fit.call_args_list[-1][1]["custom_fit"] is True
     # ranking results
     assert np.allclose(ranking_results.prefit_up, [0.0])

--- a/tests/fit/test_fit.py
+++ b/tests/fit/test_fit.py
@@ -625,9 +625,7 @@ def test_limit(example_spec_with_background, caplog):
                 {
                     "init_pars": [1.0, 0.9],
                     "fixed_params": [True, False],
-                    # par bounds has list instead of tuple, see
-                    # https://github.com/scikit-hep/pyhf/issues/1755
-                    "par_bounds": [(0.1, 10.0), [0, 5]],
+                    "par_bounds": [(0.1, 10.0), (0, 5)],
                     "test_stat": "qtilde",
                     "return_expected_set": True,
                 },

--- a/tests/fit/test_fit.py
+++ b/tests/fit/test_fit.py
@@ -629,3 +629,26 @@ def test_significance(example_spec_with_background):
     assert np.allclose(significance_results.observed_significance, 2.04096523)
     assert np.allclose(significance_results.expected_p_value, 0.02062714)
     assert np.allclose(significance_results.expected_significance, 2.04096523)
+
+    # init/fixed pars, par bounds
+    model, data = model_utils.model_and_data(example_spec_with_background)
+    with mock.patch("pyhf.infer.hypotest", return_value=(0.0, 0.0)) as mock_test:
+        fit.significance(
+            model,
+            data,
+            init_pars=[1.0, 0.9],
+            fix_pars=[True, False],
+            par_bounds=[(0.1, 10.0), (0, 5)],
+        )
+    assert mock_test.call_args_list == [
+        (
+            (0.0, data, model),
+            {
+                "init_pars": [1.0, 0.9],
+                "fixed_params": [True, False],
+                "par_bounds": [(0.1, 10.0), (0, 5)],
+                "test_stat": "q0",
+                "return_expected": True,
+            },
+        )
+    ]

--- a/tests/fit/test_fit.py
+++ b/tests/fit/test_fit.py
@@ -607,6 +607,33 @@ def test_limit(example_spec_with_background, caplog):
         fit.limit(model, data, bracket=(3.0, 3.0))
     caplog.clear()
 
+    # init/fixed pars, par bounds
+    with mock.patch("pyhf.infer.hypotest", return_value=None) as mock_test:
+        # mock return value will cause TypeError immediately after call
+        # could alternatively use mocker.spy from pytest-mock
+        with pytest.raises(TypeError):
+            fit.limit(
+                model,
+                data,
+                init_pars=[1.0, 0.9],
+                fix_pars=[True, False],
+                par_bounds=[(0.1, 10.0), (0, 5)],
+            )
+        assert mock_test.call_args_list == [
+            (
+                (0.1, data, model),
+                {
+                    "init_pars": [1.0, 0.9],
+                    "fixed_params": [True, False],
+                    # par bounds has list instead of tuple, see
+                    # https://github.com/scikit-hep/pyhf/issues/1755
+                    "par_bounds": [(0.1, 10.0), [0, 5]],
+                    "test_stat": "qtilde",
+                    "return_expected_set": True,
+                },
+            )
+        ]
+
 
 def test_significance(example_spec_with_background):
     # increase observed data for smaller observed p-value

--- a/tests/fit/test_fit.py
+++ b/tests/fit/test_fit.py
@@ -607,7 +607,7 @@ def test_limit(example_spec_with_background, caplog):
         fit.limit(model, data, bracket=(3.0, 3.0))
     caplog.clear()
 
-    # init/fixed pars, par bounds
+    # init/fixed pars, par bounds, lower POI bound below 0
     with mock.patch("pyhf.infer.hypotest", return_value=None) as mock_test:
         # mock return value will cause TypeError immediately after call
         # could alternatively use mocker.spy from pytest-mock
@@ -617,7 +617,7 @@ def test_limit(example_spec_with_background, caplog):
                 data,
                 init_pars=[1.0, 0.9],
                 fix_pars=[True, False],
-                par_bounds=[(0.1, 10.0), (0, 5)],
+                par_bounds=[(0.1, 10.0), (-1, 5)],
             )
         assert mock_test.call_args_list == [
             (
@@ -631,6 +631,10 @@ def test_limit(example_spec_with_background, caplog):
                 },
             )
         ]
+    assert "setting lower parameter bound for POI to 0" in [
+        rec.message for rec in caplog.records
+    ]
+    caplog.clear()
 
 
 def test_significance(example_spec_with_background):


### PR DESCRIPTION
This is an extension of #320, adding `init_pars` / `fix_pars` / `par_bounds` also to the remaining `fit` API: `fit.ranking`, 
`fit.scan`, `fit.limit`, `fit.significance`.

Small improvement added: set lower POI bound for limit to `0.0` only if existing bound is smaller than 0.

```
* added parameter customization options to remaining fit API
* supported keyword arguments are the same as for fit.fit: init_pars, fix_pars, and par_bounds
* set lower POI bound for limit to 0 only if default is below zero
```