### PR TITLE
perf: cache yield_stdev using spec and interpcodes of model

### DIFF
--- a/src/cabinetry/model_utils.py
+++ b/src/cabinetry/model_utils.py
@@ -167,6 +167,10 @@ def _hashable_model_key(
     The key returned by this function instead will hash to the same value for copies,
     but differ when the model represents a different likelihood.
 
+    Note: The key returned here considers only the spec and interpolation codes.
+    All other `Model` configuration options leave it unchanged
+    (e.g. `poi_name`, overriding parameter bounds, etc.).
+
     Args:
         model (pyhf.model.Model): model to generate a key for.
 

--- a/src/cabinetry/model_utils.py
+++ b/src/cabinetry/model_utils.py
@@ -163,10 +163,9 @@ def _determining_values(
     Compute a hashable representation of the values that uniquely identify a Model.
     """
     interpcodes = []
-    for mod_name in sorted(model.main_model.modifiers_appliers.keys()):
-        applier = model.main_model.modifiers_appliers[mod_name]
-        if hasattr(applier, "interpcode"):
-            interpcodes.append((mod_name, applier.interpcode))
+    for mod_type in sorted(model.config.modifier_settings.keys()):
+        code = model.config.modifier_settings[mod_type]["interpcode"]
+        interpcodes.append((mod_type, code))
     # sort since different orderings result in equivalent models,
     # but distinct strings
     spec_str = json.dumps(model.spec, sort_keys=True)

--- a/src/cabinetry/model_utils.py
+++ b/src/cabinetry/model_utils.py
@@ -156,7 +156,7 @@ def prefit_uncertainties(model: pyhf.pdf.Model) -> np.ndarray:
     return np.asarray(pre_fit_unc)
 
 
-def _determining_values(
+def _hashable_model_key(
     model: pyhf.pdf.Model,
 ) -> Tuple[str, Tuple[Tuple[str, str], ...]]:
     """
@@ -201,7 +201,7 @@ def yield_stdev(
     # check whether results are already stored in cache
     cached_results = _YIELD_STDEV_CACHE.get(
         (
-            _determining_values(model),
+            _hashable_model_key(model),
             tuple(parameters),
             tuple(uncertainty),
             corr_mat.data.tobytes(),
@@ -308,7 +308,7 @@ def yield_stdev(
     _YIELD_STDEV_CACHE.update(
         {
             (
-                _determining_values(model),
+                _hashable_model_key(model),
                 tuple(parameters),
                 tuple(uncertainty),
                 corr_mat.data.tobytes(),

--- a/src/cabinetry/model_utils.py
+++ b/src/cabinetry/model_utils.py
@@ -159,8 +159,20 @@ def prefit_uncertainties(model: pyhf.pdf.Model) -> np.ndarray:
 def _hashable_model_key(
     model: pyhf.pdf.Model,
 ) -> Tuple[str, Tuple[Tuple[str, str], ...]]:
-    """
-    Compute a hashable representation of the values that uniquely identify a Model.
+    """Compute a hashable representation of the values that uniquely identify a Model.
+
+    The `pyhf.model.Model` type is already hashable,
+    but it uses the `__hash__` inherited from `object`,
+    so a copy of a model has a distinct hash.
+    The key returned by this function instead will hash to the same value for copies,
+    but differ when the model represents a different likelihood.
+
+    Args:
+        model (pyhf.model.Model): model to generate a key for.
+
+    Returns:
+        Tuple[str, Tuple[Tuple[str, str], ...]]: a key that identifies the model
+        by its spec and interpcodes
     """
     interpcodes = []
     for mod_type in sorted(model.config.modifier_settings.keys()):

--- a/tests/test_model_utils.py
+++ b/tests/test_model_utils.py
@@ -180,7 +180,10 @@ def test_yield_stdev(example_spec, example_spec_multibin):
         assert np.allclose(total_stdev_chan[i_reg], expected_stdev_chan[i_reg])
     # also look up cache directly
     from_cache = model_utils._YIELD_STDEV_CACHE[
-        model, tuple(parameters), tuple(uncertainty), corr_mat.tobytes()
+        model_utils._determining_values(model),
+        tuple(parameters),
+        tuple(uncertainty),
+        corr_mat.tobytes(),
     ]
     for i_reg in range(2):
         assert np.allclose(from_cache[0][i_reg], expected_stdev_bin[i_reg])

--- a/tests/test_model_utils.py
+++ b/tests/test_model_utils.py
@@ -180,7 +180,7 @@ def test_yield_stdev(example_spec, example_spec_multibin):
         assert np.allclose(total_stdev_chan[i_reg], expected_stdev_chan[i_reg])
     # also look up cache directly
     from_cache = model_utils._YIELD_STDEV_CACHE[
-        model_utils._determining_values(model),
+        model_utils._hashable_model_key(model),
         tuple(parameters),
         tuple(uncertainty),
         corr_mat.tobytes(),


### PR DESCRIPTION
This implements the changes to hashing discussed in [#315](https://github.com/scikit-hep/cabinetry/issues/315#issuecomment-1023583140).

It was necessary to modify one test that was directly looking up cached results in the `yield_stdev` cache.

```
* caching for yield uncertainty calculation now based on model specification and interpolation codes
* caching now works when re-creating pyhf.pdf.Model objects
```