### PR TITLE
fix: per-channel yield uncertainty contribution from staterror-staterror terms

### DIFF
--- a/src/cabinetry/model_utils.py
+++ b/src/cabinetry/model_utils.py
@@ -289,7 +289,6 @@ def yield_stdev(
         symmetric_unc = (up_variations_ak[i_par] - down_variations_ak[i_par]) / 2
         total_variance = total_variance + symmetric_unc**2
 
-    labels = model.config.par_names()
     # continue with off-diagonal contributions if there are any
     if np.count_nonzero(corr_mat - np.diagflat(np.ones_like(parameters))) > 0:
         # loop over pairs of parameters
@@ -300,11 +299,6 @@ def yield_stdev(
                 corr = corr_mat[i_par, j_par]
                 # an approximate calculation could be done here by requiring
                 # e.g. abs(corr) > 1e-5 to continue
-                if (
-                    labels[i_par][0:10] == "staterror_"
-                    and labels[j_par][0:10] == "staterror_"
-                ):
-                    continue  # two different staterrors are orthogonal, no contribution
                 sym_unc_i = (up_variations_ak[i_par] - down_variations_ak[i_par]) / 2
                 sym_unc_j = (up_variations_ak[j_par] - down_variations_ak[j_par]) / 2
                 # factor of two below is there since loop is only over half the matrix

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -173,7 +173,7 @@ def test_integration(tmp_path, ntuple_creator, caplog):
         [[11.898333, 7.283185, 7.414715, 7.687922]],
         rtol=1e-4,
     )
-    assert np.allclose(model_postfit.total_stdev_model_channels, [20.329756], atol=1e-4)
+    assert np.allclose(model_postfit.total_stdev_model_channels, [20.439750], atol=1e-4)
     _ = cabinetry.visualize.data_mc(model_postfit, data, close_figure=True)
 
     # nuisance parameter ranking

--- a/tests/test_model_utils.py
+++ b/tests/test_model_utils.py
@@ -166,7 +166,7 @@ def test_yield_stdev(example_spec, example_spec_multibin):
         model, parameters, uncertainty, corr_mat
     )
     expected_stdev_bin = [[8.056054, 1.670629], [2.775377]]
-    expected_stdev_chan = [9.585327, 2.775377]
+    expected_stdev_chan = [9.596340, 2.775377]
     for i_reg in range(2):
         assert np.allclose(total_stdev_bin[i_reg], expected_stdev_bin[i_reg])
         assert np.allclose(total_stdev_chan[i_reg], expected_stdev_chan[i_reg])


### PR DESCRIPTION
The `model_utils.yield_stdev` implementation contained an optimization for `staterror`-`staterror` cross terms, which have no contribution when calculating per-bin uncertainties:
https://github.com/scikit-hep/cabinetry/blob/f34c73acec8d80e012ff0a4abbf44b29204af888/src/cabinetry/model_utils.py#L303-L307

When the functionality to calculate per-channel uncertainties was added in #189, the optimization should have been updated, since these cross terms no longer cancel out for the per-channel calculation. This now fixes the bug in per-channel yield uncertainties by removing this performance optimization completely.

While this does make the calculation slower overall, that is not a concern since it will be replaced completely by #316 afterwards, resulting in a significant speed-up. This intermediate fix is just meant to split the development up into steps that are hopefully easier to follow when looking back at this in the future.

resolves #323

```
* fix calculation of per-channel yield uncertainties
* calculation was previously missing contributions from staterror-staterror terms
```
