### PR TITLE
test: dedicated test for model keys

### DIFF
--- a/src/cabinetry/model_utils.py
+++ b/src/cabinetry/model_utils.py
@@ -159,20 +159,19 @@ def prefit_uncertainties(model: pyhf.pdf.Model) -> np.ndarray:
 def _hashable_model_key(
     model: pyhf.pdf.Model,
 ) -> Tuple[str, Tuple[Tuple[str, str], ...]]:
-    """Compute a hashable representation of the values that uniquely identify a Model.
+    """Compute a hashable representation of the values that uniquely identify a model.
 
-    The `pyhf.model.Model` type is already hashable,
-    but it uses the `__hash__` inherited from `object`,
-    so a copy of a model has a distinct hash.
-    The key returned by this function instead will hash to the same value for copies,
-    but differ when the model represents a different likelihood.
+    The ``pyhf.pdf.Model`` type is already hashable, but it uses the ``__hash__``
+    inherited from ``object``, so a copy of a model has a distinct hash. The key
+    returned by this function instead will hash to the same value for copies, but differ
+    when the model represents a different likelihood.
 
-    Note: The key returned here considers only the spec and interpolation codes.
-    All other `Model` configuration options leave it unchanged
-    (e.g. `poi_name`, overriding parameter bounds, etc.).
+    Note: The key returned here considers only the spec and interpolation codes. All
+    other model configuration options leave it unchanged (e.g. ``poi_name``, overriding
+    parameter bounds, etc.).
 
     Args:
-        model (pyhf.model.Model): model to generate a key for.
+        model (pyhf.model.Model): model to generate a key for
 
     Returns:
         Tuple[str, Tuple[Tuple[str, str], ...]]: a key that identifies the model

--- a/tests/test_model_utils.py
+++ b/tests/test_model_utils.py
@@ -128,6 +128,26 @@ def test_prefit_uncertainties(
     assert np.allclose(unc, [0.0, 0.0, 0.0])
 
 
+def test__hashable_model_key(example_spec):
+    # key matches for two objects built from the same spec
+    model_1 = pyhf.Workspace(example_spec).model()
+    model_2 = pyhf.Workspace(example_spec).model()
+    assert model_utils._hashable_model_key(model_1) == model_utils._hashable_model_key(
+        model_2
+    )
+
+    # key does not match if model has different interpcode
+    model_new_interpcode = pyhf.Workspace(example_spec).model(
+        modifier_settings={
+            "normsys": {"interpcode": "code1"},
+            "histosys": {"interpcode": "code0"},
+        }
+    )
+    assert model_utils._hashable_model_key(model_1) != model_utils._hashable_model_key(
+        model_new_interpcode
+    )
+
+
 def test_yield_stdev(example_spec, example_spec_multibin):
     model = pyhf.Workspace(example_spec).model()
     parameters = np.asarray([1.05, 0.95])

--- a/tests/test_model_utils.py
+++ b/tests/test_model_utils.py
@@ -129,7 +129,7 @@ def test_prefit_uncertainties(
 
 
 def test__hashable_model_key(example_spec):
-    # key matches for two objects built from the same spec
+    # key matches for two models built from the same spec
     model_1 = pyhf.Workspace(example_spec).model()
     model_2 = pyhf.Workspace(example_spec).model()
     assert model_utils._hashable_model_key(model_1) == model_utils._hashable_model_key(


### PR DESCRIPTION
This adds a dedicated unit test for the model key `model_utils. _hashable_model_key` introduced in #322, which was previously tested only via the `model_utils.yield_stdev` test.

```
* added dedicated unit test for model keys
```