### PR TITLE
chore: updating version to 0.4.1

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = cabinetry
-version = 0.4.0
+version = 0.4.1
 author = Alexander Held
 description = design and steer profile likelihood fits
 long_description = file: README.md

--- a/src/cabinetry/__init__.py
+++ b/src/cabinetry/__init__.py
@@ -13,7 +13,7 @@ import cabinetry.visualize  # noqa: F401
 import cabinetry.workspace  # noqa: F401
 
 
-__version__ = "0.4.0"
+__version__ = "0.4.1"
 
 
 def set_logging() -> None:


### PR DESCRIPTION
Updating to version `0.4.1`. This new version brings a few new features for the `cabinetry.fit` API, fixes contributions from `staterror` modifiers in the post-fit yield uncertainty calculation, and significantly speeds up the calculation of yield uncertainties.

```
* updating version to 0.4.1
```