### PR TITLE
feat: minimizer configuration for fit.fit

### DIFF
--- a/src/cabinetry/fit/__init__.py
+++ b/src/cabinetry/fit/__init__.py
@@ -154,6 +154,9 @@ def _fit_model_custom(
             see ``iminuit.Minuit.tol`` (uses EDM < 0.002*tolerance), defaults to
             None (use ``iminuit`` default of 0.1)
 
+    Raises:
+        ValueError: if minimization fails
+
     Returns:
         FitResults: object storing relevant fit results
     """
@@ -807,6 +810,9 @@ def limit(
                 expected -1 sigma, 3: expected, 4: expected +1 sigma, 5: expected +2
                 sigma
             limit_label (str): string to use when referring to the current limit
+
+        Raises:
+            ValueError: if root finding fails (usually due to starting bracket choice)
 
         Returns:
             float: absolute value of difference to CLs=``cls_target``

--- a/src/cabinetry/fit/__init__.py
+++ b/src/cabinetry/fit/__init__.py
@@ -210,8 +210,8 @@ def _fit_model_custom(
         # pick strategy like pyhf: 0 if backend provides autodiff gradients, otherwise 1
         m.strategy = 0 if pyhf.tensorlib.default_do_grad else 1
 
-    m.tol = tolerance or 0.1  # goal: EDM < 0.002*tol*errordef
     maxiter = maxiter or 100_000
+    m.tol = tolerance or 0.1  # goal: EDM < 0.002*tol*errordef
 
     m.migrad(ncall=maxiter)
     m.hesse()  # use default call limit (consistent with pyhf)

--- a/tests/fit/test_fit.py
+++ b/tests/fit/test_fit.py
@@ -144,6 +144,7 @@ def test__fit_model_custom(mock_minos, example_spec, example_spec_multibin):
     # propagation of max iterations and tolerance
     model, data = model_utils.model_and_data(example_spec)
     mock_minuit_instance = mock.MagicMock()
+    mock_minuit_instance.errors = [0.1, 0.1]  # needed as it will be accessed
     with mock.patch("iminuit.Minuit", return_value=mock_minuit_instance):
         # mocked minuit instance used to check correct propagation of settings
         fit._fit_model_custom(model, data)

--- a/tests/fit/test_fit.py
+++ b/tests/fit/test_fit.py
@@ -209,7 +209,7 @@ def test__fit_model(mock_pyhf, mock_custom, example_spec):
     }
     assert np.allclose(fit_results.bestfit, [1.1])
 
-    # pyhf API, init/fixed pars, par bounds, minos, maxiter/tolerance
+    # pyhf API, init/fixed pars, par bounds, minos, strategy/maxiter/tolerance
     fit_results = fit._fit_model(
         model,
         data,
@@ -217,6 +217,7 @@ def test__fit_model(mock_pyhf, mock_custom, example_spec):
         init_pars=[1.5, 2.0],
         fix_pars=[False, True],
         par_bounds=[(0, 5), (0.1, 10.0)],
+        strategy=2,
         maxiter=100,
         tolerance=0.01,
     )
@@ -228,7 +229,7 @@ def test__fit_model(mock_pyhf, mock_custom, example_spec):
         "init_pars": [1.5, 2.0],
         "fix_pars": [False, True],
         "par_bounds": [(0, 5), (0.1, 10.0)],
-        "strategy": None,
+        "strategy": 2,
         "maxiter": 100,
         "tolerance": 0.01,
     }

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -183,12 +183,12 @@ def test_integration(tmp_path, ntuple_creator, caplog):
     assert np.allclose(
         ranking_results.prefit_up,
         [
-            -1.67766172,
-            -1.51712811,
+            -1.67617185,
+            -1.51531885,
             -0.14964691,
-            -0.10787925,
+            -0.11067885,
             0.14350015,
-            -0.11328328,
+            -0.11311905,
             -0.05573699,
         ],
     )
@@ -196,37 +196,37 @@ def test_integration(tmp_path, ntuple_creator, caplog):
         ranking_results.prefit_down,
         [
             1.41570164,
-            1.15025176,
-            0.17084682,
-            0.10910502,
-            -0.15092356,
-            0.1162032,
-            0.05864963,
+            1.15001063,
+            0.16388633,
+            0.10921275,
+            -0.15331233,
+            0.11492629,
+            0.05864962,
         ],
     )
     assert np.allclose(
         ranking_results.postfit_up,
         [
-            -1.10138138,
-            -0.89692663,
-            -0.14842105,
-            -0.10503361,
-            0.13866138,
-            -0.10801323,
-            -0.05485056,
+            -1.10235942,
+            -0.89697066,
+            -0.14842092,
+            -0.10774037,
+            0.13866107,
+            -0.10800505,
+            -0.0548506,
         ],
         atol=1e-4,
     )
     assert np.allclose(
         ranking_results.postfit_down,
         [
-            0.84367903,
-            0.76574073,
-            0.1693045,
-            0.10604551,
-            -0.14654595,
-            0.11081914,
-            0.05779502,
+            0.84366301,
+            0.76572728,
+            0.16236075,
+            0.10604544,
+            -0.14383307,
+            0.10888311,
+            0.05779505,
         ],
         atol=1e-4,
     )
@@ -242,7 +242,7 @@ def test_integration(tmp_path, ntuple_creator, caplog):
     )
     # lower edge of scan is beyond normalization factor bounds specified in workspace
     assert np.allclose(
-        scan_results.delta_nlls, [0.27153966, 0.0, 0.29018620], atol=5e-5
+        scan_results.delta_nlls, [0.27163227, 0.0, 0.29018620], atol=5e-5
     )
 
     # upper limit, this calculation is slow


### PR DESCRIPTION
Adding minimizer configuration options to `cabinetry.fit`: `strategy`, `maxiter` and `tolerance` allow configuring the Minuit strategy, maximum number of iterations and tolerance for Migrad. This extends the `fit` API functionality, similarly to #320 and #321.

When fitting with `custom_fit=True`, a `ValueError` is now raised if the fit fails.

Since the `pyhf` fit API does not support `strategy=None` currently (see https://github.com/scikit-hep/pyhf/issues/1785), the strategy kwarg is only propagated for values other than `None`. This can be refactored in the future in case this changes.

The integration test changes are due to the default tolerance with `custom_fit=True` now matching the default when using the `pyhf` fit API (previously the tolerance was reduced by a factor of ten).

partially addresses #329

```
* added minimizer configuration options to fit.fit
* new supported keyword arguments are strategy, maxiter and tolerance
* raise ValueError when fits with custom_fit=True fail
```