### PR TITLE
build: remove wheel from build-system requirements

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=42", "wheel"]
+requires = ["setuptools>=42"]
 build-backend = "setuptools.build_meta"
 
 [tool.black]


### PR DESCRIPTION
As pointed out by @henryiii (thanks!), `wheel` is not required in the list of `build-system` requirements according to [PEP 517](https://www.python.org/dev/peps/pep-0517/). See https://github.com/scikit-hep/pylhe/pull/111 and https://github.com/scikit-hep/pyhf/pull/1788.

```
* remove superfluous wheel requirement in build-system
```