### PR TITLE
feat: return yield tables

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,7 @@ repos:
         additional_dependencies: ["numpy>=1.20", "boost-histogram>=1.0.1", "click>=8", "types-tabulate", "types-PyYAML"]
         args: ["--python-version=3.10"]
 -   repo: https://github.com/pycqa/flake8
-    rev: 4.0.1
+    rev: 5.0.4
     hooks:
     -   id: flake8
         additional_dependencies: [flake8-bugbear, flake8-import-order, flake8-print]


### PR DESCRIPTION
Return dict with yield tables from `tabulate.yields` (this previously returned `None`).

This can be argued to be a breaking change; while it seems unlikely that anyone is relying on the return value of `None`, marking this as "breaking" to be safe.

```
* breaking change: return dict with yield tables from tabulate.yields
* updated pre-commit
```