### PR TITLE
ci: update versions of GitHub actions and pre-commit

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - uses: actions/setup-python@v3
+    - uses: actions/setup-python@v4
     - uses: pre-commit/action@v2.0.3
 
   test:
@@ -27,7 +27,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install cabinetry and dependencies

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -15,6 +15,8 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - uses: actions/setup-python@v4
+      with:
+        python-version: '3.9'
     - uses: pre-commit/action@v3.0.0
 
   test:
@@ -22,7 +24,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.7, 3.8, 3.9]
+        python-version: ['3.7', '3.8', '3.9']
 
     steps:
     - uses: actions/checkout@v3
@@ -51,15 +53,15 @@ jobs:
       run: |
         python -m pip install .[pyhf_backends]  # install pyhf backends
     - name: Test with pytest and generate coverage report
-      if: matrix.python-version == 3.7
+      if: matrix.python-version == '3.7'
       run: |
         pytest --runslow --cov-report=xml
     - name: Test with pytest
-      if: matrix.python-version != 3.7
+      if: matrix.python-version != '3.7'
       run: |
         pytest --runslow
     - name: Upload coverage to codecov
-      if: matrix.python-version == 3.7
+      if: matrix.python-version == '3.7'
       uses: codecov/codecov-action@v3
       with:
         token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - uses: actions/setup-python@v4
-    - uses: pre-commit/action@v2.0.3
+    - uses: pre-commit/action@v3.0.0
 
   test:
     runs-on: ubuntu-latest
@@ -60,7 +60,7 @@ jobs:
         pytest --runslow
     - name: Upload coverage to codecov
       if: matrix.python-version == 3.7
-      uses: codecov/codecov-action@v2
+      uses: codecov/codecov-action@v3
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         file: ./coverage.xml

--- a/.github/workflows/dependencies-head.yml
+++ b/.github/workflows/dependencies-head.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: [3.9]
+        python-version: ['3.9']
 
     steps:
     - uses: actions/checkout@v3
@@ -38,7 +38,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: [3.9]
+        python-version: ['3.9']
 
     steps:
     - uses: actions/checkout@v3
@@ -63,7 +63,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: [3.9]
+        python-version: ['3.9']
 
     steps:
     - uses: actions/checkout@v3
@@ -88,7 +88,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: [3.9]
+        python-version: ['3.9']
 
     steps:
     - uses: actions/checkout@v3
@@ -114,7 +114,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: [3.9]
+        python-version: ['3.9']
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/dependencies-head.yml
+++ b/.github/workflows/dependencies-head.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
@@ -43,7 +43,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
@@ -68,7 +68,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
@@ -93,7 +93,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
@@ -119,7 +119,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies

--- a/.github/workflows/test-package.yml
+++ b/.github/workflows/test-package.yml
@@ -22,7 +22,7 @@ jobs:
     - name: Set up Python 3.9
       uses: actions/setup-python@v4
       with:
-        python-version: 3.9
+        python-version: '3.9'
 
     - name: Install python-build, check-manifest, and twine
       run: |

--- a/.github/workflows/test-package.yml
+++ b/.github/workflows/test-package.yml
@@ -20,7 +20,7 @@ jobs:
         fetch-depth: 0
 
     - name: Set up Python 3.9
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v4
       with:
         python-version: 3.9
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@ repos:
     hooks:
     -   id: black
 -   repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.942
+    rev: v0.961
     hooks:
     -   id: mypy
         name: mypy with Python 3.7
@@ -22,12 +22,12 @@ repos:
     -   id: flake8
         additional_dependencies: [flake8-bugbear, flake8-import-order, flake8-print]
 -   repo: https://github.com/asottile/pyupgrade
-    rev: v2.31.1
+    rev: v2.34.0
     hooks:
     -   id: pyupgrade
         args: ["--py37-plus"]
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.1.0
+    rev: v4.3.0
     hooks:
     -   id: check-added-large-files
         args: ["--maxkb=100"]


### PR DESCRIPTION
Updating GitHub actions:
- `setup-python` v4: https://github.com/actions/setup-python/releases/tag/v4.0.0
- `pre-commit` v3: https://github.com/pre-commit/action/releases/tag/v3.0.0
- `codecov` v3: https://github.com/codecov/codecov-action/releases/tag/v3.1.0

Also including a pre-commit update.

```
* updated versions of GitHub actions: setup-python v4, pre-commit v3, codecov v3
* use strings for Python versions in CI
* updated pre-commit
```