### PR TITLE
feat: explicitly set post-fit parameter errors to 0 for fixed parameters

### DIFF
--- a/src/cabinetry/fit/__init__.py
+++ b/src/cabinetry/fit/__init__.py
@@ -85,7 +85,10 @@ def _fit_model_pyhf(
     log.info(f"MINUIT status:\n{result_obj.minuit.fmin}")
 
     bestfit = pyhf.tensorlib.to_numpy(result[:, 0])
-    uncertainty = pyhf.tensorlib.to_numpy(result[:, 1])
+    # set errors for fixed parameters to 0 (see iminuit#762)
+    uncertainty = np.where(
+        result_obj.minuit.fixed, 0.0, pyhf.tensorlib.to_numpy(result[:, 1])
+    )
     labels = model.config.par_names()
     corr_mat = pyhf.tensorlib.to_numpy(corr_mat)
     best_twice_nll = float(best_twice_nll)  # convert 0-dim np.ndarray to float
@@ -180,7 +183,8 @@ def _fit_model_custom(
     log.info(f"MINUIT status:\n{m.fmin}")
 
     bestfit = np.asarray(m.values)
-    uncertainty = np.asarray(m.errors)
+    # set errors for fixed parameters to 0 (see iminuit#762)
+    uncertainty = np.where(m.fixed, 0.0, m.errors)
     corr_mat = m.covariance.correlation()  # iminuit.util.Matrix, subclass of np.ndarray
     best_twice_nll = m.fval
 

--- a/src/cabinetry/fit/__init__.py
+++ b/src/cabinetry/fit/__init__.py
@@ -150,10 +150,6 @@ def _fit_model_custom(
 
     labels = model.config.par_names()
 
-    # set initial step size to 0 for fixed parameters
-    # this will cause the associated parameter uncertainties to be 0 post-fit
-    step_size = [0.1 if not fix_pars[i_par] else 0.0 for i_par in range(len(init_pars))]
-
     def twice_nll_func(pars: np.ndarray) -> Any:
         """The objective for minimization: twice the negative log-likelihood.
 
@@ -170,7 +166,6 @@ def _fit_model_custom(
         return twice_nll[0]
 
     m = iminuit.Minuit(twice_nll_func, init_pars, name=labels)
-    m.errors = step_size
     m.fixed = fix_pars
     m.limits = par_bounds
     m.errordef = 1


### PR DESCRIPTION
Starting from `iminuit` version v2.12.1, running MIGRAD will set non-zero step sizes for all parameters (including fixed parameters) and does no longer just carry through the value of `0.0` that `cabinetry` sets for them before minimization. See https://github.com/scikit-hep/iminuit/issues/762 for details. To keep post-fit parameter uncertainties for fixed parameters at zero, this now sets the relevant values to `0.0` after minimization. As there is no longer any benefit to setting the value to zero before the fit, the initial step size settings are removed.

```
* explicitly set post-fit parameter errors to 0 for fixed parameters for compatibility with iminuit>=2.12.1
```