### PR TITLE
feat: make POI optional in config and allow POI customization for inference

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -56,7 +56,7 @@ filterwarnings =
     ignore:no code associated:UserWarning:typeguard:
 
 [flake8]
-max-complexity = 16
+max-complexity = 18
 max-line-length = 88
 exclude = docs/conf.py
 count = True

--- a/src/cabinetry/fit/__init__.py
+++ b/src/cabinetry/fit/__init__.py
@@ -470,15 +470,9 @@ def ranking(
     labels = model.config.par_names()
     prefit_unc = model_utils.prefit_uncertainties(model)
 
-    if poi is not None:
-        # use POI given by kwarg if specified
-        poi_index = model_utils._parameter_index(poi, labels)
-        if poi_index == -1:
-            raise ValueError(f"parameter {poi} not found in model")
-    elif model.config.poi_index is not None:
-        # use POI specified in model
-        poi_index = model.config.poi_index
-    else:
+    # use POI given by kwarg, fall back to POI specified in model
+    poi_index = model_utils._poi_index(model, poi=poi)
+    if poi_index is None:
         raise ValueError("no POI specified, cannot calculate impacts")
 
     nominal_poi = fit_results.bestfit[poi_index]

--- a/src/cabinetry/fit/__init__.py
+++ b/src/cabinetry/fit/__init__.py
@@ -597,7 +597,7 @@ def scan(
 
     # get index of parameter with name par_name
     par_index = model_utils._parameter_index(par_name, labels)
-    if par_index == -1:
+    if par_index is None:
         raise ValueError(f"parameter {par_name} not found in model")
 
     # run a fit with the parameter not held constant, to find the best-fit point

--- a/src/cabinetry/fit/__init__.py
+++ b/src/cabinetry/fit/__init__.py
@@ -473,7 +473,7 @@ def ranking(
     # use POI given by kwarg, fall back to POI specified in model
     poi_index = model_utils._poi_index(model, poi=poi)
     if poi_index is None:
-        raise ValueError("no POI specified, cannot calculate impacts")
+        raise ValueError("no POI specified, cannot calculate ranking")
 
     nominal_poi = fit_results.bestfit[poi_index]
 

--- a/src/cabinetry/model_utils.py
+++ b/src/cabinetry/model_utils.py
@@ -424,12 +424,14 @@ def unconstrained_parameter_count(model: pyhf.pdf.Model) -> int:
     return n_pars
 
 
-def _parameter_index(par_name: str, labels: Union[List[str], Tuple[str, ...]]) -> int:
+def _parameter_index(
+    par_name: str, labels: Union[List[str], Tuple[str, ...]]
+) -> Optional[int]:
     """Returns the position of a parameter with a given name in the list of parameters.
 
     Useful together with ``pyhf.pdf._ModelConfig.par_names`` to find the position of a
     parameter when the name is known. If the parameter is not found, logs an error and
-    returns a default value of -1.
+    returns a default value of None.
 
     Args:
         par_name (str): name of parameter to find in list
@@ -437,10 +439,10 @@ def _parameter_index(par_name: str, labels: Union[List[str], Tuple[str, ...]]) -
             names in the model
 
     Returns:
-        int: index of parameter
+        Optional[int]: index of parameter, or None if parameter was not found
     """
-    par_index = next((i for i, label in enumerate(labels) if label == par_name), -1)
-    if par_index == -1:
+    par_index = next((i for i, label in enumerate(labels) if label == par_name), None)
+    if par_index is None:
         log.error(f"parameter {par_name} not found in model")
     return par_index
 

--- a/src/cabinetry/model_utils.py
+++ b/src/cabinetry/model_utils.py
@@ -447,6 +447,38 @@ def _parameter_index(
     return par_index
 
 
+def _poi_index(model: pyhf.pdf.Model, *, poi: Optional[str] = None) -> Optional[int]:
+    """Returns the index of the POI specified in the argument or the model default.
+
+    If a string is given as argument, this takes priority. Otherwise the POI from the
+    model is used. If no POI is specified there either, logs an error and returns a
+    default value of None.
+
+    Args:
+        model (pyhf.pdf.Model): model for which to find the POI index
+        poi (Optional[str], optional): name of the POI, defaults to None
+
+    Raises:
+        ValueError: if the specified POI name cannot be found in the model
+
+    Returns:
+        Optional[int]: POI index, or None if no POI could be found
+    """
+    if poi is not None:
+        # use POI given by kwarg if specified
+        poi_index = _parameter_index(poi, model.config.par_names())
+        if poi_index is None:
+            raise ValueError(f"parameter {poi} not found in model")
+    elif model.config.poi_index is not None:
+        # use POI specified in model
+        poi_index = model.config.poi_index
+    else:
+        log.error("could not find POI for model")
+        poi_index = None
+
+    return poi_index
+
+
 def _strip_auxdata(model: pyhf.pdf.Model, data: List[float]) -> List[float]:
     """Always returns observed yields, no matter whether data includes auxdata.
 

--- a/src/cabinetry/model_utils.py
+++ b/src/cabinetry/model_utils.py
@@ -447,7 +447,9 @@ def _parameter_index(
     return par_index
 
 
-def _poi_index(model: pyhf.pdf.Model, *, poi: Optional[str] = None) -> Optional[int]:
+def _poi_index(
+    model: pyhf.pdf.Model, *, poi_name: Optional[str] = None
+) -> Optional[int]:
     """Returns the index of the POI specified in the argument or the model default.
 
     If a string is given as argument, this takes priority. Otherwise the POI from the
@@ -456,7 +458,7 @@ def _poi_index(model: pyhf.pdf.Model, *, poi: Optional[str] = None) -> Optional[
 
     Args:
         model (pyhf.pdf.Model): model for which to find the POI index
-        poi (Optional[str], optional): name of the POI, defaults to None
+        poi_name (Optional[str], optional): name of the POI, defaults to None
 
     Raises:
         ValueError: if the specified POI name cannot be found in the model
@@ -464,11 +466,11 @@ def _poi_index(model: pyhf.pdf.Model, *, poi: Optional[str] = None) -> Optional[
     Returns:
         Optional[int]: POI index, or None if no POI could be found
     """
-    if poi is not None:
+    if poi_name is not None:
         # use POI given by kwarg if specified
-        poi_index = _parameter_index(poi, model.config.par_names())
+        poi_index = _parameter_index(poi_name, model.config.par_names())
         if poi_index is None:
-            raise ValueError(f"parameter {poi} not found in model")
+            raise ValueError(f"parameter {poi_name} not found in model")
     elif model.config.poi_index is not None:
         # use POI specified in model
         poi_index = model.config.poi_index

--- a/src/cabinetry/schemas/config.json
+++ b/src/cabinetry/schemas/config.json
@@ -62,14 +62,14 @@
             "$$target": "#/definitions/general",
             "description": "general settings",
             "type": "object",
-            "required": ["Measurement", "POI", "InputPath", "HistogramFolder"],
+            "required": ["Measurement", "InputPath", "HistogramFolder"],
             "properties": {
                 "Measurement": {
                     "description": "name of measurement",
                     "type": "string"
                 },
                 "POI": {
-                    "description": "name of parameter of interest",
+                    "description": "name of parameter of interest, defaults to empty string",
                     "type": "string"
                 },
                 "InputPath": {

--- a/src/cabinetry/workspace.py
+++ b/src/cabinetry/workspace.py
@@ -358,7 +358,8 @@ class WorkspaceBuilder:
 
         parameters = {"parameters": parameters_list}
         config_dict.update(parameters)
-        config_dict.update({"poi": self.config["General"]["POI"]})
+        # POI defaults to "" (interpreted as "no POI" by pyhf) if not specified
+        config_dict.update({"poi": self.config["General"].get("POI", "")})
         measurement.update({"config": config_dict})
         measurements.append(measurement)
         return measurements

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -18,7 +18,6 @@ def test_validate():
     config_valid = {
         "General": {
             "Measurement": "",
-            "POI": "",
             "HistogramFolder": "",
             "InputPath": "",
         },
@@ -32,7 +31,6 @@ def test_validate():
     config_multiple_data_samples = {
         "General": {
             "Measurement": "",
-            "POI": "",
             "HistogramFolder": "",
             "InputPath": "",
         },

--- a/tests/test_model_utils.py
+++ b/tests/test_model_utils.py
@@ -343,11 +343,11 @@ def test__poi_index(example_spec, caplog):
     model = pyhf.Workspace(example_spec).model()
 
     # POI given by name
-    assert model_utils._poi_index(model, "staterror_Signal-Region[0]") == 1
+    assert model_utils._poi_index(model, poi="staterror_Signal-Region[0]") == 1
 
     # parameter not found in model
     with pytest.raises(ValueError, match="parameter x not found in model"):
-        model_utils._poi_index(model, "x")
+        model_utils._poi_index(model, poi="x")
 
     # POI specified in model config
     assert model_utils._poi_index(model) == 0

--- a/tests/test_model_utils.py
+++ b/tests/test_model_utils.py
@@ -343,11 +343,11 @@ def test__poi_index(example_spec, caplog):
     model = pyhf.Workspace(example_spec).model()
 
     # POI given by name
-    assert model_utils._poi_index(model, poi="staterror_Signal-Region[0]") == 1
+    assert model_utils._poi_index(model, poi_name="staterror_Signal-Region[0]") == 1
 
     # parameter not found in model
     with pytest.raises(ValueError, match="parameter x not found in model"):
-        model_utils._poi_index(model, poi="x")
+        model_utils._poi_index(model, poi_name="x")
 
     # POI specified in model config
     assert model_utils._poi_index(model) == 0

--- a/tests/test_model_utils.py
+++ b/tests/test_model_utils.py
@@ -332,7 +332,7 @@ def test__parameter_index(caplog):
     assert model_utils._parameter_index(par_name, tuple(labels)) == 1
     caplog.clear()
 
-    assert model_utils._parameter_index("x", labels) == -1
+    assert model_utils._parameter_index("x", labels) is None
     assert "parameter x not found in model" in [rec.message for rec in caplog.records]
     caplog.clear()
 

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -315,9 +315,9 @@ def test_WorkspaceBuilder_channels(mock_contains, mock_histogram):
     assert mock_histogram.call_count == 1
 
 
-def test_WorkspaceBuilder_get_measurement():
+def test_WorkspaceBuilder_measurements():
     example_config = {
-        "General": {"Measurement": "fit", "POI": "mu", "HistogramFolder": "path"},
+        "General": {"Measurement": "fit", "HistogramFolder": "path"},
         "NormFactors": [
             {"Name": "NF", "Nominal": 1.0, "Bounds": [0.0, 5.0], "Fixed": False}
         ],
@@ -326,7 +326,7 @@ def test_WorkspaceBuilder_get_measurement():
         {
             "name": "fit",
             "config": {
-                "poi": "mu",
+                "poi": "",
                 "parameters": [{"name": "NF", "inits": [1.0], "bounds": [[0.0, 5.0]]}],
             },
         }
@@ -334,7 +334,7 @@ def test_WorkspaceBuilder_get_measurement():
     ws_builder = workspace.WorkspaceBuilder(example_config)
     assert ws_builder.measurements() == expected_measurement
 
-    # no norm factor settings
+    # no norm factor settings, POI specified
     example_config_no_NF_settings = {
         "General": {"Measurement": "fit", "POI": "mu", "HistogramFolder": "path"},
         "NormFactors": [{"Name": "NF"}],
@@ -372,7 +372,6 @@ def test_WorkspaceBuilder_get_measurement():
         example_config_const_sys = {
             "General": {
                 "Measurement": "fit",
-                "POI": "mu",
                 "Fixed": [{"Name": "par_A", "Value": 1.2}],
                 "HistogramFolder": "path",
             },
@@ -382,7 +381,7 @@ def test_WorkspaceBuilder_get_measurement():
             {
                 "name": "fit",
                 "config": {
-                    "poi": "mu",
+                    "poi": "",
                     "parameters": [{"name": "par_A", "fixed": True, "inits": [1.2]}],
                 },
             }
@@ -397,11 +396,11 @@ def test_WorkspaceBuilder_get_measurement():
         return_value=None,
     ) as mock_find_const:
         example_config_sys = {
-            "General": {"Measurement": "fit", "POI": "mu", "HistogramFolder": "path"},
+            "General": {"Measurement": "fit", "HistogramFolder": "path"},
             "Systematics": [{"Name": "par_A"}],
         }
         expected_measurement_sys = [
-            {"name": "fit", "config": {"poi": "mu", "parameters": []}}
+            {"name": "fit", "config": {"poi": "", "parameters": []}}
         ]
         ws_builder = workspace.WorkspaceBuilder(example_config_sys)
         assert ws_builder.measurements() == expected_measurement_sys

--- a/tests/visualize/test_visualize_plot_model.py
+++ b/tests/visualize/test_visualize_plot_model.py
@@ -108,7 +108,7 @@ def test_data_mc(tmp_path, caplog):
     histo_dict_list[1]["yields"] = np.asarray([0, 5])
     caplog.clear()
     with mock.patch("cabinetry.visualize.utils._save_and_close") as mock_close_safe:
-        with pytest.warns(None) as warn_record:
+        with pytest.warns() as warn_record:
             fig = fig = plot_model.data_mc(
                 histo_dict_list,
                 total_model_unc_log,


### PR DESCRIPTION
The changes in https://github.com/scikit-hep/pyhf/pull/1638 and https://github.com/scikit-hep/pyhf/pull/1636 made POIs in `pyhf` workspaces optional. This means they can also be optional for the `cabinetry` config when building models. If not specified, the POI defaults to `""` which is interpreted as "no POI" by `pyhf`.

A new keyword argument `poi_name` was added to `fit.ranking` and `fit.limit` to override the POI given in the model config.

Also fixing a deprecation warning observed in a test.

resolves #347

```
* POI is now an optional configuration argument
* added ability to set POI via poi_name keyword arguments in fit.ranking and fit.limit
* fixed pytest deprecation warning in a test
```