### PR TITLE
fix: avoid mixing different versions of awkward in uproot5 tests

### DIFF
--- a/.github/workflows/dependencies-head.yml
+++ b/.github/workflows/dependencies-head.yml
@@ -76,7 +76,7 @@ jobs:
         python -m pip install --upgrade pip setuptools wheel
         python -m pip install --ignore-installed --upgrade -q --no-cache-dir -e .[test]
         python -m pip uninstall --yes uproot
-        python -m pip install --upgrade --no-cache-dir git+https://github.com/scikit-hep/uproot4.git
+        python -m pip install --upgrade --no-cache-dir git+https://github.com/scikit-hep/uproot5.git
         python -m pip list
     - name: Test with pytest
       run: |

--- a/src/cabinetry/contrib/histogram_creator.py
+++ b/src/cabinetry/contrib/histogram_creator.py
@@ -3,7 +3,6 @@
 import pathlib
 from typing import List, Optional
 
-import awkward as ak
 import boost_histogram as bh
 import numpy as np
 import uproot
@@ -60,8 +59,8 @@ def with_uproot(
         obs_list = []
         weight_list = []
         for arr in array_generator:
-            obs_list.append(ak.to_numpy(arr[variable]))
-            weight_list.append(ak.to_numpy(arr[weight]))
+            obs_list.append(arr[variable].to_numpy())
+            weight_list.append(arr[weight].to_numpy())
         observables = np.concatenate(obs_list)
         weights = np.concatenate(weight_list)
 
@@ -72,7 +71,7 @@ def with_uproot(
         )
         obs_list = []
         for arr in array_generator:
-            obs_list.append(ak.to_numpy(arr[variable]))
+            obs_list.append(arr[variable].to_numpy())
         observables = np.concatenate(obs_list)
         weights = np.ones_like(observables) * float(weight)
 


### PR DESCRIPTION
The tests of the most recent versions of dependencies started failing for `uproot5`. The reason is that `uproot5` uses the `awkward` v2 API, but the histogram creation code in `cabinetry` uses `awkward` directly as well (which currently results in v1). The two do not mix:
```python
import awkward as ak
a = ak._v2.Array([1,2,3])
ak.to_numpy(a)
```
results in
```pytb
TypeError: unrecognized array type: <Array [1, 2, 3] type='3 * int64'>
```
The solution is to call `.to_numpy()` on the relevant arrays instead, which will then use the v2 API in these tests. As `uproot5` and `awkward` v2 should release at the same time, this probably would not have an impact on users, but this change should keep the tests working.

```
* fix test of upcoming versions of uproot5
```