### PR TITLE
feat: add version to command line interface

### DIFF
--- a/src/cabinetry/cli/__init__.py
+++ b/src/cabinetry/cli/__init__.py
@@ -9,6 +9,7 @@ from typing import Any, List, Optional, Tuple
 import click
 import yaml
 
+from cabinetry import __version__
 from cabinetry import configuration as cabinetry_configuration
 from cabinetry import fit as cabinetry_fit
 from cabinetry import model_utils as cabinetry_model_utils
@@ -33,6 +34,7 @@ def _set_logging() -> None:
     logging.getLogger("pyhf").setLevel(logging.WARNING)
 
 
+@click.version_option(version=__version__)
 @click.group(cls=OrderedGroup)
 def cabinetry() -> None:
     """Entrypoint to the cabinetry CLI."""

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -7,6 +7,7 @@ import numpy as np
 import pytest
 import yaml
 
+from cabinetry import __version__
 from cabinetry import cli
 from cabinetry import fit
 
@@ -28,6 +29,10 @@ def test_cabinetry():
     result = runner.invoke(cli.cabinetry, ["--help"])
     assert result.exit_code == 0
     assert "Entrypoint to the cabinetry CLI." in result.output
+
+    result = runner.invoke(cli.cabinetry, ["--version"])
+    assert result.exit_code == 0
+    assert f"cabinetry, version {__version__}" in result.output
 
 
 # using autospec to catch changes in public API


### PR DESCRIPTION
The CLI did not support `cabinetry --version` so far, so this is added here via built-in `click` functionality.

```
* add support for cabinetry --version to the command line interface
```