### PR TITLE
feat: save yield tables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ build
 *.npy
 *.npz
 *.json
+tables/
 
 # sphinx
 docs/_build

--- a/src/cabinetry/tabulate.py
+++ b/src/cabinetry/tabulate.py
@@ -45,8 +45,7 @@ def _save_tables(
 ) -> None:
     """Saves yield tables in a specific format in a given folder.
 
-    New lines are removed from table fields to prevent unwanted interactions with some
-    table formats.
+    Newlines are removed from table headers for table formats that do not support them.
 
     Args:
         table_dict (Dict[str, List[Dict[str, Any]]]): dictionary with tables to save

--- a/src/cabinetry/tabulate.py
+++ b/src/cabinetry/tabulate.py
@@ -40,6 +40,7 @@ def _header_name(channel_name: str, i_bin: int, *, unique: bool = True) -> str:
 def _save_tables(
     table_dict: Dict[str, List[Dict[str, Any]]],
     table_folder: pathlib.Path,
+    table_label: str,
     table_format: str,
 ) -> None:
     """Saves yield tables in a specific format in a given folder.
@@ -50,6 +51,7 @@ def _save_tables(
     Args:
         table_dict (Dict[str, List[Dict[str, Any]]]): dictionary with tables to save
         table_folder (pathlib.Path): path to the folder to save tables in
+        table_label (str): label for table to include in filename
         table_format (str): format in which to save the table
     """
     if table_format in ["plain", "simple", "tsv"]:
@@ -62,7 +64,7 @@ def _save_tables(
     table_folder.mkdir(parents=True, exist_ok=True)
 
     for table_type in table_dict.keys():
-        table_path = table_folder / f"{table_type}.{save_suffix}"
+        table_path = table_folder / f"{table_type}_{table_label}.{save_suffix}"
 
         if table_type == "yields_per_bin" and table_format in ["html", "latex", "tsv"]:
             # replace newlines in table headers for formats that do not support them
@@ -287,6 +289,8 @@ def yields(
         table_dict.update({"yields_per_channel": per_channel_table})
 
     # save tables to file
-    _save_tables(table_dict, pathlib.Path(table_folder), table_format)
+    _save_tables(
+        table_dict, pathlib.Path(table_folder), model_prediction.label, table_format
+    )
 
     return table_dict

--- a/src/cabinetry/tabulate.py
+++ b/src/cabinetry/tabulate.py
@@ -214,6 +214,7 @@ def yields(
     per_channel: bool = False,
     table_folder: Union[str, pathlib.Path] = "tables",
     table_format: str = "simple",
+    save_tables: bool = True,
 ) -> Dict[str, List[Dict[str, Any]]]:
     """Generates yield tables, showing model prediction and data.
 
@@ -231,11 +232,12 @@ def yields(
             to True
         per_channel (bool, optional): whether to show a table with yields per channel,
             defaults to False
-        table_folder (Union[str, pathlib.Path]): path to the folder to save tables in,
-            defaults to "tables"
-        table_format (str): format in which to save the table, can be any of the formats
-            supported by ``tabulate`` (e.g. html, latex, plain, simple, tsv), defaults
-            to "simple"
+        table_folder (Union[str, pathlib.Path], optional): path to the folder to save
+            tables in, defaults to "tables"
+        table_format (str, optional): format in which to save the table, can be any of
+            the formats ``tabulate`` supports (e.g. html, latex, plain, simple, tsv),
+            defaults to "simple"
+        save_tables (bool, optional): whether to save tables, defaults to True
 
     Returns:
         Dict[str, List[Dict[str, Any]]]: dictionary with yield tables for use with the
@@ -288,8 +290,9 @@ def yields(
         table_dict.update({"yields_per_channel": per_channel_table})
 
     # save tables to file
-    _save_tables(
-        table_dict, pathlib.Path(table_folder), model_prediction.label, table_format
-    )
+    if save_tables:
+        _save_tables(
+            table_dict, pathlib.Path(table_folder), model_prediction.label, table_format
+        )
 
     return table_dict

--- a/src/cabinetry/tabulate.py
+++ b/src/cabinetry/tabulate.py
@@ -234,7 +234,7 @@ def yields(
             defaults to False
         table_folder (Union[str, pathlib.Path], optional): path to the folder to save
             tables in, defaults to "tables"
-        table_format (str, optional): format in which to save the table, can be any of
+        table_format (str, optional): format in which to save the tables, can be any of
             the formats ``tabulate`` supports (e.g. html, latex, plain, simple, tsv),
             defaults to "simple"
         save_tables (bool, optional): whether to save tables, defaults to True

--- a/src/cabinetry/tabulate.py
+++ b/src/cabinetry/tabulate.py
@@ -289,8 +289,8 @@ def yields(
         )
         table_dict.update({"yields_per_channel": per_channel_table})
 
-    # save tables to file
     if save_tables:
+        # save tables to file
         _save_tables(
             table_dict, pathlib.Path(table_folder), model_prediction.label, table_format
         )

--- a/src/cabinetry/tabulate.py
+++ b/src/cabinetry/tabulate.py
@@ -50,8 +50,8 @@ def _save_tables(
     Args:
         table_dict (Dict[str, List[Dict[str, Any]]]): dictionary with tables to save
         table_folder (pathlib.Path): path to the folder to save tables in
-        table_label (str): label for table to include in filename
-        table_format (str): format in which to save the table
+        table_label (str): label for tables to include in filenames
+        table_format (str): format in which to save the tables
     """
     if table_format in ["plain", "simple", "tsv"]:
         save_suffix = "txt"

--- a/tests/test_tabulate.py
+++ b/tests/test_tabulate.py
@@ -72,6 +72,73 @@ def test__yields_per_bin(example_spec_multibin, example_spec_with_background, ca
     ]
 
 
+def test__save_tables(tmp_path):
+    table_dict = {
+        "yields_per_bin": [
+            {
+                "sample": "Background",
+                "Signal_region\nbin 1": "111.00",
+                "Signal_region\nbin 2": "116.00",
+            },
+            {
+                "sample": "Signal",
+                "Signal_region\nbin 1": "1.00",
+                "Signal_region\nbin 2": "5.00",
+            },
+            {
+                "sample": "total",
+                "Signal_region\nbin 1": "112.00 ± 10.00",
+                "Signal_region\nbin 2": "121.00 ± 11.00",
+            },
+            {
+                "sample": "data",
+                "Signal_region\nbin 1": "112.00",
+                "Signal_region\nbin 2": "123.00",
+            },
+        ],
+        "yields_per_channel": [
+            {"sample": "Background", "Signal_region": "227.00"},
+            {"sample": "Signal", "Signal_region": "6.00"},
+            {"sample": "total", "Signal_region": "233.00 ± 17.00"},
+            {"sample": "data", "Signal_region": "235.00"},
+        ],
+    }
+
+    tabulate._save_tables(table_dict, tmp_path, "abc", "simple")
+    fname_bin = tmp_path / "yields_per_bin_abc.txt"
+    fname_channel = tmp_path / "yields_per_channel_abc.txt"
+    assert fname_bin.is_file()  # bin table saved
+    assert fname_channel.is_file()  # channel table saved
+    assert fname_bin.read_text() == (
+        "sample      Signal_region    Signal_region\n"
+        "            bin 1            bin 2\n"
+        "----------  ---------------  ---------------\n"
+        "Background  111.00           116.00\n"
+        "Signal      1.00             5.00\n"
+        "total       112.00 ± 10.00   121.00 ± 11.00\n"
+        "data        112.00           123.00\n"
+    )
+    assert fname_channel.read_text() == (
+        "sample      Signal_region\n"
+        "----------  ---------------\n"
+        "Background  227.00\n"
+        "Signal      6.00\n"
+        "total       233.00 ± 17.00\n"
+        "data        235.00\n"
+    )
+
+    # suffix for latex, modification of newlines in header
+    tabulate._save_tables(table_dict, tmp_path, "abc", "latex")
+    fname_bin = tmp_path / "yields_per_bin_abc.tex"
+    assert fname_bin.is_file()
+    assert fname_bin.read_text().split("&")[1] == " Signal\\_region, bin 1   "
+
+    # unchanged suffix for other formats
+    tabulate._save_tables(table_dict, tmp_path, "abc", "html")
+    fname_bin = tmp_path / "yields_per_bin_abc.html"
+    assert fname_bin.is_file()
+
+
 def test__yields_per_channel(
     example_spec_multibin, example_spec_with_background, caplog
 ):


### PR DESCRIPTION
Automatically save yield tables when they are produced. The destination and format are customizable and controlled by new `tabulate.yields` keyword arguments: `table_folder` and `table_format`. The format can be any of the formats supported by the `tabulate` library, see https://github.com/astanin/python-tabulate#table-format. The automatic saving of tables can be turned off via `save_tables`.

```
* support automatic saving of yield tables in customizable formats
```