### PR TITLE
fix: remove unnecessary dependencies for mypy

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,12 +9,12 @@ repos:
     -   id: mypy
         name: mypy with Python 3.7
         files: src/cabinetry
-        additional_dependencies: ["numpy>=1.22", "boost-histogram>=1.0.1", "click>=8", "types-tabulate", "types-PyYAML", "uhi", "importlib_metadata"]
+        additional_dependencies: ["numpy>=1.22", "boost-histogram>=1.0.1", "click>=8", "types-tabulate", "types-PyYAML"]
         args: ["--python-version=3.7"]
     -   id: mypy
         name: mypy with Python 3.10
         files: src/cabinetry
-        additional_dependencies: ["numpy>=1.22", "boost-histogram>=1.0.1", "click>=8", "types-tabulate", "types-PyYAML", "uhi"]
+        additional_dependencies: ["numpy>=1.22", "boost-histogram>=1.0.1", "click>=8", "types-tabulate", "types-PyYAML"]
         args: ["--python-version=3.10"]
 -   repo: https://github.com/pycqa/flake8
     rev: 5.0.4


### PR DESCRIPTION
#333 changed the pre-commit config, adding additional dependencies to the `mypy` stage. Those were needed to make things run locally, but they do not seem to be needed anymore in a clean environment (nor were they required previously). Removing them again as things seem to run fine without them.

```
* remove unnecessary dependencies for mypy running in pre-commit
```