### PR TITLE
feat: yield uncertainties per sample

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -39,7 +39,7 @@ repos:
         # configuration duplicated in setup.cfg
         args: ["--match=(?!setup|example).*\\.py'", "--match-dir='^(?!(tests|utils|docs)).*'", "--convention=google"]
 -   repo: https://github.com/codespell-project/codespell
-    rev: v2.1.0
+    rev: v2.2.1
     hooks:
     -   id: codespell
         args: ["-L", "hist", "src", "tests", "utils", "docs/*rst"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ python_version = "3.7"
 module = [
     "uproot",
     "awkward",
+    "awkward._v2",
     "pyhf",
     "matplotlib.*",
     "iminuit",

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,7 +25,7 @@ python_requires = >=3.7
 install_requires =
     pyhf[minuit]~=0.7.0rc1  # model.config.suggested_fixed API change
     boost_histogram>=1.0.0  # subclassing with family, 1.02 for stdev scaling fix (currently not needed)
-    awkward>=1.8  # _v2 API with from_iter support
+    awkward>=1.8  # _v2 API in submodule
     tabulate>=0.8.1  # multiline text
     matplotlib
     typing_extensions;python_version<"3.8"  # for Literal type

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,7 +25,7 @@ python_requires = >=3.7
 install_requires =
     pyhf[minuit]~=0.7.0rc1  # model.config.suggested_fixed API change
     boost_histogram>=1.0.0  # subclassing with family, 1.02 for stdev scaling fix (currently not needed)
-    awkward>=1.0  # new API
+    awkward>=1.8  # _v2 API with from_iter support
     tabulate>=0.8.1  # multiline text
     matplotlib
     typing_extensions;python_version<"3.8"  # for Literal type

--- a/src/cabinetry/model_utils.py
+++ b/src/cabinetry/model_utils.py
@@ -279,7 +279,7 @@ def yield_stdev(
         # indices: variation, channel, sample, bin
         up_variations.append(up_yields)
 
-        # total model distribution with this parameter varied down
+        # model distribution per sample with this parameter varied down
         down_comb = pyhf.tensorlib.to_numpy(
             model.main_model.expected_data(down_pars, return_by_sample=True)
         )

--- a/src/cabinetry/model_utils.py
+++ b/src/cabinetry/model_utils.py
@@ -8,9 +8,9 @@ from typing import Any, DefaultDict, Dict, List, NamedTuple, Optional, Tuple, Un
 try:
     # use awkward v2
     import awkward._v2 as ak
-except ModuleNotFoundError:
+except ModuleNotFoundError:  # pragma: no cover
     # fallback if the _v2 submodule disappears after the full v2 release
-    import awkward as ak
+    import awkward as ak  # pragma: no cover
 import numpy as np
 import pyhf
 

--- a/src/cabinetry/model_utils.py
+++ b/src/cabinetry/model_utils.py
@@ -302,11 +302,11 @@ def yield_stdev(
     down_variations_ak = ak.from_iter(down_variations)
 
     # calculate symmetric uncertainties for all components
-    # indices: variation, channel (last entry sum), sample (last entry sum), bin
+    # indices: variation, channel (last entries sums), sample (last entry sum), bin
     sym_uncs = (up_variations_ak - down_variations_ak) / 2
 
     # calculate total variance, indexed by channel, sample, bin (per-channel numbers act
-    # like additional one-bin channel)
+    # like additional channels with one bin each)
     if np.count_nonzero(corr_mat - np.diagflat(np.ones_like(parameters))) == 0:
         # no off-diagonal contributions from correlation matrix (e.g. pre-fit)
         total_variance = ak.sum(np.power(sym_uncs, 2), axis=0)

--- a/src/cabinetry/model_utils.py
+++ b/src/cabinetry/model_utils.py
@@ -345,19 +345,6 @@ def yield_stdev(
     log.debug(f"total stdev is {total_stdev_per_bin[:, -1, :]}")
     log.debug(f"total stdev per channel is {total_stdev_per_channel[:, -1]}")
 
-    # temporary output for debugging purposes
-    for i, channel in enumerate(model.config.channels):
-        print(f"channel: {channel}")
-        for j, sample in enumerate(model.config.samples):
-            print(
-                f"sample: {sample:15s}, uncs per bin: {total_stdev_per_bin[i, j]}, "
-                f"uncs per channel: {total_stdev_per_channel[i,j]:.3f}"
-            )
-        print(
-            f"total: uncs per bin: {total_stdev_per_bin[i, -1]}, "
-            f"uncs per channel: {total_stdev_per_channel[i,-1]:.3f}"
-        )
-
     # convert to lists
     total_stdev_per_bin = ak.to_list(total_stdev_per_bin)
     total_stdev_per_channel = ak.to_list(total_stdev_per_channel)

--- a/src/cabinetry/tabulate.py
+++ b/src/cabinetry/tabulate.py
@@ -189,7 +189,7 @@ def _yields_per_channel(
             sample_dict.update(
                 {
                     channel_name: f"{model_yields[i_chan][i_sam]:.2f} "
-                    f"\u00B1 {total_stdev_model[i_chan][i_sam]:.3f}"
+                    f"\u00B1 {total_stdev_model[i_chan][i_sam]:.2f}"
                 }
             )
         table.append(sample_dict)

--- a/src/cabinetry/visualize/__init__.py
+++ b/src/cabinetry/visualize/__init__.py
@@ -235,7 +235,7 @@ def data_mc(
 
         fig = plot_model.data_mc(
             histogram_dict_list,
-            np.asarray(model_prediction.total_stdev_model_bins[i_chan]),
+            np.asarray(model_prediction.total_stdev_model_bins[i_chan][-1]),
             bin_edges,
             figure_path=figure_path,
             log_scale=log_scale,

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -162,18 +162,36 @@ def test_integration(tmp_path, ntuple_creator, caplog):
     model_prefit = cabinetry.model_utils.prediction(model)
     assert np.allclose(
         model_prefit.total_stdev_model_bins,
-        [[69.040789, 58.343328, 38.219599, 45.296964]],
+        [
+            [
+                [69.040789, 58.329118, 37.973787, 45.137157],  # background
+                [0.0, 0.100772, 1.487773, 1.620867],  # signal
+                [69.040789, 58.343328, 38.219599, 45.296964],  # sum over samples
+            ]
+        ],
     )
-    assert np.allclose(model_prefit.total_stdev_model_channels, [136.791978])
+    assert np.allclose(
+        model_prefit.total_stdev_model_channels, [[136.368732, 2.851565, 136.791978]]
+    )
     _ = cabinetry.visualize.data_mc(model_prefit, data, close_figure=True)
 
     model_postfit = cabinetry.model_utils.prediction(model, fit_results=fit_results)
     assert np.allclose(
         model_postfit.total_stdev_model_bins,
-        [[11.898333, 7.283185, 7.414715, 7.687922]],
+        [
+            [
+                [11.898551, 7.513216, 21.002006, 24.284847],  # background
+                [0.0, 1.467646, 22.137293, 22.269200],  # signal
+                [11.898551, 7.283171, 7.414715, 7.687966],  # sum over samples
+            ]
+        ],
         rtol=1e-4,
     )
-    assert np.allclose(model_postfit.total_stdev_model_channels, [20.439750], atol=5e-4)
+    assert np.allclose(
+        model_postfit.total_stdev_model_channels,
+        [[41.043814, 45.814417, 20.439575]],
+        atol=5e-4,
+    )
     _ = cabinetry.visualize.data_mc(model_postfit, data, close_figure=True)
 
     # nuisance parameter ranking

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -190,7 +190,7 @@ def test_integration(tmp_path, ntuple_creator, caplog):
     assert np.allclose(
         model_postfit.total_stdev_model_channels,
         [[41.043814, 45.814417, 20.439575]],
-        atol=5e-4,
+        atol=2e-3,
     )
     _ = cabinetry.visualize.data_mc(model_postfit, data, close_figure=True)
 

--- a/tests/test_tabulate.py
+++ b/tests/test_tabulate.py
@@ -22,7 +22,7 @@ def test__yields_per_bin(example_spec_multibin, example_spec_with_background, ca
     # multiple channels
     model = pyhf.Workspace(example_spec_multibin).model()
     yields = [[[25.0, 5.0]], [[8.0]]]
-    total_stdev = [[5.0, 2.0], [1.0]]
+    total_stdev = [[[5.0, 2.0], [5.0, 2.0]], [[1.0], [1.0]]]
     data = [[35, 8], [10]]
     channels = model.config.channels
     label = "pre-fit"
@@ -34,9 +34,9 @@ def test__yields_per_bin(example_spec_multibin, example_spec_with_background, ca
     assert yield_table == [
         {
             "sample": "Signal",
-            "region_1\nbin 1": "25.00",
-            "region_1\nbin 2": "5.00",
-            "region_2\nbin 1": "8.00",
+            "region_1\nbin 1": "25.00 \u00B1 5.00",
+            "region_1\nbin 2": "5.00 \u00B1 2.00",
+            "region_2\nbin 1": "8.00 \u00B1 1.00",
         },
         {
             "sample": "total",
@@ -57,7 +57,7 @@ def test__yields_per_bin(example_spec_multibin, example_spec_with_background, ca
     # multiple samples
     model = pyhf.Workspace(example_spec_with_background).model()
     yields = [[[150.0], [50.0]]]
-    total_stdev = [[8.60]]
+    total_stdev = [[[6.45], [2.15], [8.60]]]
     data = [[160]]
     channels = model.config.channels
 
@@ -65,8 +65,8 @@ def test__yields_per_bin(example_spec_multibin, example_spec_with_background, ca
         model, yields, total_stdev, data, channels, label
     )
     assert yield_table == [
-        {"sample": "Background", "Signal Region\nbin 1": "150.00"},
-        {"sample": "Signal", "Signal Region\nbin 1": "50.00"},
+        {"sample": "Background", "Signal Region\nbin 1": "150.00 \u00B1 6.45"},
+        {"sample": "Signal", "Signal Region\nbin 1": "50.00 \u00B1 2.15"},
         {"sample": "total", "Signal Region\nbin 1": "200.00 \u00B1 8.60"},
         {"sample": "data", "Signal Region\nbin 1": "160.00"},
     ]
@@ -77,18 +77,18 @@ def test__save_tables(tmp_path):
         "yields_per_bin": [
             {
                 "sample": "Background",
-                "Signal_region\nbin 1": "111.00",
-                "Signal_region\nbin 2": "116.00",
+                "Signal_region\nbin 1": "111.00 \u00B1 9.50",
+                "Signal_region\nbin 2": "116.00 \u00B1 10.00",
             },
             {
                 "sample": "Signal",
-                "Signal_region\nbin 1": "1.00",
-                "Signal_region\nbin 2": "5.00",
+                "Signal_region\nbin 1": "1.00 \u00B1 0.50",
+                "Signal_region\nbin 2": "5.00 \u00B1 1.00",
             },
             {
                 "sample": "total",
-                "Signal_region\nbin 1": "112.00 ± 10.00",
-                "Signal_region\nbin 2": "121.00 ± 11.00",
+                "Signal_region\nbin 1": "112.00 \u00B1 10.00",
+                "Signal_region\nbin 2": "121.00 \u00B1 11.00",
             },
             {
                 "sample": "data",
@@ -97,9 +97,9 @@ def test__save_tables(tmp_path):
             },
         ],
         "yields_per_channel": [
-            {"sample": "Background", "Signal_region": "227.00"},
-            {"sample": "Signal", "Signal_region": "6.00"},
-            {"sample": "total", "Signal_region": "233.00 ± 17.00"},
+            {"sample": "Background", "Signal_region": "227.00 \u00B1 16.00"},
+            {"sample": "Signal", "Signal_region": "6.00 \u00B1 1.00"},
+            {"sample": "total", "Signal_region": "233.00 \u00B1 17.00"},
             {"sample": "data", "Signal_region": "235.00"},
         ],
     }
@@ -113,17 +113,17 @@ def test__save_tables(tmp_path):
         "sample      Signal_region    Signal_region\n"
         "            bin 1            bin 2\n"
         "----------  ---------------  ---------------\n"
-        "Background  111.00           116.00\n"
-        "Signal      1.00             5.00\n"
-        "total       112.00 ± 10.00   121.00 ± 11.00\n"
+        "Background  111.00 \u00B1 9.50    116.00 \u00B1 10.00\n"
+        "Signal      1.00 \u00B1 0.50      5.00 \u00B1 1.00\n"
+        "total       112.00 \u00B1 10.00   121.00 \u00B1 11.00\n"
         "data        112.00           123.00\n"
     )
     assert fname_channel.read_text() == (
         "sample      Signal_region\n"
         "----------  ---------------\n"
-        "Background  227.00\n"
-        "Signal      6.00\n"
-        "total       233.00 ± 17.00\n"
+        "Background  227.00 \u00B1 16.00\n"
+        "Signal      6.00 \u00B1 1.00\n"
+        "total       233.00 \u00B1 17.00\n"
         "data        235.00\n"
     )
 
@@ -147,7 +147,7 @@ def test__yields_per_channel(
     # multiple channels
     model = pyhf.Workspace(example_spec_multibin).model()
     yields = [[30], [8.0]]
-    total_stdev = [5.39, 1.0]
+    total_stdev = [[5.39, 5.39], [1.0, 1.0]]
     data = [43, 10]
     channels = model.config.channels
     label = "pre-fit"
@@ -157,7 +157,11 @@ def test__yields_per_channel(
         model, yields, total_stdev, data, channels, label
     )
     assert yield_table == [
-        {"sample": "Signal", "region_1": "30.00", "region_2": "8.00"},
+        {
+            "sample": "Signal",
+            "region_1": "30.00 \u00B1 5.39",
+            "region_2": "8.00 \u00B1 1.00",
+        },
         {
             "sample": "total",
             "region_1": "30.00 \u00B1 5.39",
@@ -173,7 +177,7 @@ def test__yields_per_channel(
     # multiple samples
     model = pyhf.Workspace(example_spec_with_background).model()
     yields = [[150.0, 50]]
-    total_stdev = [8.60]
+    total_stdev = [[6.45, 2.15, 8.60]]
     data = [160]
     channels = model.config.channels
 
@@ -181,8 +185,8 @@ def test__yields_per_channel(
         model, yields, total_stdev, data, channels, label
     )
     assert yield_table == [
-        {"sample": "Background", "Signal Region": "150.00"},
-        {"sample": "Signal", "Signal Region": "50.00"},
+        {"sample": "Background", "Signal Region": "150.00 \u00B1 6.45"},
+        {"sample": "Signal", "Signal Region": "50.00 \u00B1 2.15"},
         {"sample": "total", "Signal Region": "200.00 \u00B1 8.60"},
         {"sample": "data", "Signal Region": "160.00"},
     ]
@@ -205,14 +209,16 @@ def test_yields(
     # to be able to check that they are correctly propagated to the output
     caplog.set_level(logging.DEBUG)
     model = pyhf.Workspace(example_spec).model()
-    model_pred = model_utils.ModelPrediction(model, [[[10.0]]], [[0.3]], [0.3], "pred")
+    model_pred = model_utils.ModelPrediction(
+        model, [[[10.0]]], [[[0.3]]], [[0.3]], "pred"
+    )
     data = [12.0, 1.0]  # with auxdata to strip via mock
 
     table_dict = tabulate.yields(model_pred, data)
     assert mock_data.call_args_list == [((model, data), {})]
     assert mock_filter.call_args_list == [((model, None), {})]
     assert mock_bin.call_args_list == [
-        ((model, [[[10.0]]], [[0.3]], [[12.0]], ["SR"], "pred"), {})
+        ((model, [[[10.0]]], [[[0.3]]], [[12.0]], ["SR"], "pred"), {})
     ]
     assert mock_channel.call_count == 0
     assert mock_save.call_count == 1
@@ -239,7 +245,7 @@ def test_yields(
     )
     assert mock_bin.call_count == 1  # one call from before
     assert mock_channel.call_args_list == [
-        ((model, [[10.0]], [0.3], [12.0], ["SR"], "pred"), {})
+        ((model, [[10.0]], [[0.3]], [12.0], ["SR"], "pred"), {})
     ]
     assert table_dict == {"yields_per_channel": [{"yields_per_channel": None}]}
     assert mock_save.call_count == 1  # one call from before, no new call

--- a/tests/test_tabulate.py
+++ b/tests/test_tabulate.py
@@ -210,7 +210,7 @@ def test_yields(
     caplog.set_level(logging.DEBUG)
     model = pyhf.Workspace(example_spec).model()
     model_pred = model_utils.ModelPrediction(
-        model, [[[10.0]]], [[[0.3]]], [[0.3]], "pred"
+        model, [[[10.0]]], [[[0.3], [0.3]]], [[0.3, 0.3]], "pred"
     )
     data = [12.0, 1.0]  # with auxdata to strip via mock
 
@@ -218,7 +218,7 @@ def test_yields(
     assert mock_data.call_args_list == [((model, data), {})]
     assert mock_filter.call_args_list == [((model, None), {})]
     assert mock_bin.call_args_list == [
-        ((model, [[[10.0]]], [[[0.3]]], [[12.0]], ["SR"], "pred"), {})
+        ((model, [[[10.0]]], [[[0.3], [0.3]]], [[12.0]], ["SR"], "pred"), {})
     ]
     assert mock_channel.call_count == 0
     assert mock_save.call_count == 1
@@ -245,7 +245,7 @@ def test_yields(
     )
     assert mock_bin.call_count == 1  # one call from before
     assert mock_channel.call_args_list == [
-        ((model, [[10.0]], [[0.3]], [12.0], ["SR"], "pred"), {})
+        ((model, [[10.0]], [[0.3, 0.3]], [12.0], ["SR"], "pred"), {})
     ]
     assert table_dict == {"yields_per_channel": [{"yields_per_channel": None}]}
     assert mock_save.call_count == 1  # one call from before, no new call

--- a/tests/visualize/test_visualize.py
+++ b/tests/visualize/test_visualize.py
@@ -149,7 +149,7 @@ def test_data_mc(mock_data, mock_filter, mock_dict, mock_bins, mock_draw, exampl
     figure_folder = "tmp"
     model = pyhf.Workspace(example_spec).model()
     model_pred = model_utils.ModelPrediction(
-        model, [[[10.0]]], [[[0.3]]], [[0.3]], "pre-fit"
+        model, [[[10.0]]], [[[0.3], [0.3]]], [[0.3, 0.3]], "pre-fit"
     )
     data = [12.0, 1.0]
 
@@ -198,7 +198,7 @@ def test_data_mc(mock_data, mock_filter, mock_dict, mock_bins, mock_draw, exampl
     # do not save figure, histogram input mode: no binning or variable specified (via
     # side effect)
     model_pred = model_utils.ModelPrediction(
-        model, [[[11.0]]], [[[0.2]]], [[0.2]], "post-fit"
+        model, [[[11.0]]], [[[0.2], [0.2]]], [[0.2, 0.2]], "post-fit"
     )
     _ = visualize.data_mc(
         model_pred,

--- a/tests/visualize/test_visualize.py
+++ b/tests/visualize/test_visualize.py
@@ -149,7 +149,7 @@ def test_data_mc(mock_data, mock_filter, mock_dict, mock_bins, mock_draw, exampl
     figure_folder = "tmp"
     model = pyhf.Workspace(example_spec).model()
     model_pred = model_utils.ModelPrediction(
-        model, [[[10.0]]], [[0.3]], [0.3], "pre-fit"
+        model, [[[10.0]]], [[[0.3]]], [[0.3]], "pre-fit"
     )
     data = [12.0, 1.0]
 
@@ -198,7 +198,7 @@ def test_data_mc(mock_data, mock_filter, mock_dict, mock_bins, mock_draw, exampl
     # do not save figure, histogram input mode: no binning or variable specified (via
     # side effect)
     model_pred = model_utils.ModelPrediction(
-        model, [[[11.0]]], [[0.2]], [0.2], "post-fit"
+        model, [[[11.0]]], [[[0.2]]], [[0.2]], "post-fit"
     )
     _ = visualize.data_mc(
         model_pred,


### PR DESCRIPTION
Adds per-sample yield uncertainty calculations and the propagation to yield tables.

The per-sample calculation is not implemented as an optional choice, but always performed. With everything already vectorized, the calculation is still fast with reasonably large models. If this becomes a bottleneck, it may make sense to allow making the per-sample calculation optional.

resolves #191

resolves #326 by switching to `awkward._v2` for the summation where this matters

**breaking changes**:
- `model_utils.ModelPrediction` changed: new sample dimension for `total_stdev_model_bins`  / `total_stdev_model_channels`
- `model_utils.yield_stdev` returns this new version of `ModelPrediction`

```
* breaking change: model_utils.ModelPrediction uncertainty structure now supports per-sample uncertainties
* breaking change: model_utils.yield_stdev (and model_utils.prediction) returns this new structure
* switch to awkward v2 API for yield uncertainty calculations
* raise awkward version requirement to awkward>=1.8
* updated pre-commit
```