### PR TITLE
feat: support disabling staterror per sample in workspace creation

### DIFF
--- a/src/cabinetry/schemas/config.json
+++ b/src/cabinetry/schemas/config.json
@@ -198,8 +198,8 @@
                     "description": "if it is a data sample",
                     "type": "boolean"
                 },
-                "AddStaterror": {
-                    "description": "whether to automatically include a staterror modifier for this sample, defaults to True",
+                "DisableStaterror": {
+                    "description": "whether to disable the automatic inclusion of staterror modifiers for this sample, defaults to False",
                     "type": "boolean"
                 },
                 "Regions": {

--- a/src/cabinetry/schemas/config.json
+++ b/src/cabinetry/schemas/config.json
@@ -198,6 +198,10 @@
                     "description": "if it is a data sample",
                     "type": "boolean"
                 },
+                "AddStaterror": {
+                    "description": "whether to automatically include a staterror modifier for this sample, defaults to True",
+                    "type": "boolean"
+                },
                 "Regions": {
                     "description": "region(s) that contain the sample, defaults to all regions",
                     "$ref": "#/definitions/regions_setting"

--- a/src/cabinetry/workspace.py
+++ b/src/cabinetry/workspace.py
@@ -286,8 +286,8 @@ class WorkspaceBuilder:
                 modifiers = []
 
                 # gammas
-                if sample.get("AddStaterror", True):
-                    # staterror modifiers added by default, controlled via AddStaterror
+                if sample.get("DisableStaterror", False):
+                    # staterror modifiers are added unless DisableStaterror is True
                     gammas = {}
                     gammas.update(
                         {"name": "staterror_" + region["Name"].replace(" ", "-")}

--- a/src/cabinetry/workspace.py
+++ b/src/cabinetry/workspace.py
@@ -286,11 +286,15 @@ class WorkspaceBuilder:
                 modifiers = []
 
                 # gammas
-                gammas = {}
-                gammas.update({"name": "staterror_" + region["Name"].replace(" ", "-")})
-                gammas.update({"type": "staterror"})
-                gammas.update({"data": sample_hist.stdev.tolist()})
-                modifiers.append(gammas)
+                if sample.get("AddStaterror", True):
+                    # staterror modifiers added by default, controlled via AddStaterror
+                    gammas = {}
+                    gammas.update(
+                        {"name": "staterror_" + region["Name"].replace(" ", "-")}
+                    )
+                    gammas.update({"type": "staterror"})
+                    gammas.update({"data": sample_hist.stdev.tolist()})
+                    modifiers.append(gammas)
 
                 # modifiers can have region and sample dependence, which is checked
                 # check if normfactors affect sample in region, add modifiers as needed

--- a/src/cabinetry/workspace.py
+++ b/src/cabinetry/workspace.py
@@ -286,7 +286,7 @@ class WorkspaceBuilder:
                 modifiers = []
 
                 # gammas
-                if sample.get("DisableStaterror", False):
+                if not sample.get("DisableStaterror", False):
                     # staterror modifiers are added unless DisableStaterror is True
                     gammas = {}
                     gammas.update(

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -256,7 +256,9 @@ def test_WorkspaceBuilder_sys_modifiers(mock_norm, mock_norm_shape):
     "cabinetry.workspace.histo.Histogram.from_config",
     return_value=histo.Histogram.from_arrays([0, 1, 2], [1.0, 2.0], [0.1, 0.1]),
 )
-@mock.patch("cabinetry.configuration.region_contains_sample", side_effect=[True, False])
+@mock.patch(
+    "cabinetry.configuration.region_contains_sample", side_effect=[True, False, True]
+)
 def test_WorkspaceBuilder_channels(mock_contains, mock_histogram):
     # should mock normfactor_modifiers / sys_modifiers
     example_config = {
@@ -313,6 +315,17 @@ def test_WorkspaceBuilder_channels(mock_contains, mock_histogram):
     )
     # no calls to read histogram content
     assert mock_histogram.call_count == 1
+
+    # staterror creation disabled
+    example_config = {
+        "General": {"HistogramFolder": "path"},
+        "Regions": [{"Name": "region_1"}],
+        "Samples": [{"Name": "signal", "DisableStaterror": True}],
+        "NormFactors": [],
+    }
+    ws_builder = workspace.WorkspaceBuilder(example_config)
+    channels = ws_builder.channels()
+    assert channels[0]["samples"][0]["modifiers"] == []
 
 
 def test_WorkspaceBuilder_measurements():


### PR DESCRIPTION
Added a new config option `DisableStaterror` for samples. It defaults to false, and can be set to true in order to skip the creation of automatic `staterror` modifiers for the respective sample during workspace building.

resolves #276

```
* added sample configuration option "DisableStaterror" to disable automatic creation of staterror modifiers
```