### PR TITLE
feat: minimizer configuration for general inference

### DIFF
--- a/src/cabinetry/fit/__init__.py
+++ b/src/cabinetry/fit/__init__.py
@@ -651,6 +651,9 @@ def scan(
     init_pars: Optional[List[float]] = None,
     fix_pars: Optional[List[bool]] = None,
     par_bounds: Optional[List[Tuple[float, float]]] = None,
+    strategy: Optional[Literal[0, 1, 2]] = None,
+    maxiter: Optional[int] = None,
+    tolerance: Optional[float] = None,
     custom_fit: bool = False,
 ) -> ScanResults:
     """Performs a likelihood scan over the specified parameter.
@@ -673,6 +676,14 @@ def scan(
             parameters are held constant, defaults to None (use ``pyhf`` suggestion)
         par_bounds (Optional[List[Tuple[float, float]]], optional): list of tuples with
             parameter bounds for fit, defaults to None (use ``pyhf`` suggested bounds)
+        strategy (Optional[Literal[0, 1, 2]], optional): minimization strategy used by
+            Minuit, can be 0/1/2, defaults to None (then uses ``pyhf`` default behavior
+            of strategy 0 with user-provided gradients and 1 otherwise)
+        maxiter (Optional[int], optional): allowed number of calls for minimization,
+            defaults to None (use ``pyhf`` default of 100,000)
+        tolerance (Optional[float]), optional): tolerance for convergence, for details
+            see ``iminuit.Minuit.tol`` (uses EDM < 0.002*tolerance), defaults to
+            None (use ``iminuit`` default of 0.1)
         custom_fit (bool, optional): whether to use the ``pyhf.infer`` API or
             ``iminuit``, defaults to False (using ``pyhf.infer``)
 
@@ -697,6 +708,9 @@ def scan(
         init_pars=init_pars,
         fix_pars=fix_pars,
         par_bounds=par_bounds,
+        strategy=strategy,
+        maxiter=maxiter,
+        tolerance=tolerance,
         custom_fit=custom_fit,
     )
     nominal_twice_nll = fit_results.best_twice_nll
@@ -732,6 +746,9 @@ def scan(
             init_pars=init_pars_scan,
             fix_pars=fix_pars,
             par_bounds=par_bounds,
+            strategy=strategy,
+            maxiter=maxiter,
+            tolerance=tolerance,
             custom_fit=custom_fit,
         )
         # subtract best-fit

--- a/src/cabinetry/fit/__init__.py
+++ b/src/cabinetry/fit/__init__.py
@@ -1032,6 +1032,9 @@ def significance(
     init_pars: Optional[List[float]] = None,
     fix_pars: Optional[List[bool]] = None,
     par_bounds: Optional[List[Tuple[float, float]]] = None,
+    strategy: Optional[Literal[0, 1, 2]] = None,
+    maxiter: Optional[int] = None,
+    tolerance: Optional[float] = None,
 ) -> SignificanceResults:
     """Calculates the discovery significance of a positive signal.
 
@@ -1046,12 +1049,25 @@ def significance(
             parameters are held constant, defaults to None (use ``pyhf`` suggestion)
         par_bounds (Optional[List[Tuple[float, float]]], optional): list of tuples with
             parameter bounds for fit, defaults to None (use ``pyhf`` suggested bounds)
+        strategy (Optional[Literal[0, 1, 2]], optional): minimization strategy used by
+            Minuit, can be 0/1/2, defaults to None (then uses ``pyhf`` default behavior
+            of strategy 0 with user-provided gradients and 1 otherwise)
+        maxiter (Optional[int], optional): allowed number of calls for minimization,
+            defaults to None (use ``pyhf`` default of 100,000)
+        tolerance (Optional[float]), optional): tolerance for convergence, for details
+            see ``iminuit.Minuit.tol`` (uses EDM < 0.002*tolerance), defaults to
+            None (use ``iminuit`` default of 0.1)
 
     Returns:
         SignificanceResults: observed and expected p-values and significances
     """
     _, initial_optimizer = pyhf.get_backend()  # store initial optimizer settings
-    pyhf.set_backend(pyhf.tensorlib, pyhf.optimize.minuit_optimizer(verbose=1))
+    pyhf.set_backend(
+        pyhf.tensorlib,
+        pyhf.optimize.minuit_optimizer(
+            verbose=1, strategy=strategy, maxiter=maxiter, tolerance=tolerance
+        ),
+    )
 
     log.info("calculating discovery significance")
     obs_p_val, exp_p_val = pyhf.infer.hypotest(

--- a/src/cabinetry/fit/__init__.py
+++ b/src/cabinetry/fit/__init__.py
@@ -763,8 +763,8 @@ def limit(
     data: List[float],
     *,
     bracket: Optional[Union[List[float], Tuple[float, float]]] = None,
-    tolerance: float = 0.01,
-    maxiter: int = 100,
+    poi_tolerance: float = 0.01,
+    maxsteps: int = 100,
     confidence_level: float = 0.95,
     poi_name: Optional[str] = None,
     init_pars: Optional[List[float]] = None,
@@ -787,9 +787,9 @@ def limit(
             lie between these values and the values must not be the same, defaults to
             None (then uses 0.1 as default lower value and the upper POI bound
             specified in the measurement as default upper value)
-        tolerance (float, optional): tolerance in POI value for convergence to target
-            CLs value (1-``confidence_level``), defaults to 0.01
-        maxiter (int, optional): maximum number of steps for limit finding, defaults to
+        poi_tolerance (float, optional): tolerance in POI value for convergence to
+            target CLs value (1-``confidence_level``), defaults to 0.01
+        maxsteps (int, optional): maximum number of steps for limit finding, defaults to
             100
         confidence_level (float, optional): confidence level for calculation, defaults
             to 0.95 (95%)
@@ -942,7 +942,7 @@ def limit(
                 bracket=bracket,
                 args=(model, data, cls_target, i_limit, limit_label),
                 method="brentq",
-                options={"xtol": tolerance, "maxiter": maxiter},
+                options={"xtol": poi_tolerance, "maxiter": maxsteps},
             )
         except ValueError:
             # invalid starting bracket is most common issue

--- a/src/cabinetry/fit/__init__.py
+++ b/src/cabinetry/fit/__init__.py
@@ -505,6 +505,9 @@ def ranking(
     init_pars: Optional[List[float]] = None,
     fix_pars: Optional[List[bool]] = None,
     par_bounds: Optional[List[Tuple[float, float]]] = None,
+    strategy: Optional[Literal[0, 1, 2]] = None,
+    maxiter: Optional[int] = None,
+    tolerance: Optional[float] = None,
     custom_fit: bool = False,
 ) -> RankingResults:
     """Calculates the impact of nuisance parameters on the parameter of interest (POI).
@@ -527,6 +530,14 @@ def ranking(
             parameters are held constant, defaults to None (use ``pyhf`` suggestion)
         par_bounds (Optional[List[Tuple[float, float]]], optional): list of tuples with
             parameter bounds for fit, defaults to None (use ``pyhf`` suggested bounds)
+        strategy (Optional[Literal[0, 1, 2]], optional): minimization strategy used by
+            Minuit, can be 0/1/2, defaults to None (then uses ``pyhf`` default behavior
+            of strategy 0 with user-provided gradients and 1 otherwise)
+        maxiter (Optional[int], optional): allowed number of calls for minimization,
+            defaults to None (use ``pyhf`` default of 100,000)
+        tolerance (Optional[float]), optional): tolerance for convergence, for details
+            see ``iminuit.Minuit.tol`` (uses EDM < 0.002*tolerance), defaults to
+            None (use ``iminuit`` default of 0.1)
         custom_fit (bool, optional): whether to use the ``pyhf.infer`` API or
             ``iminuit``, defaults to False (using ``pyhf.infer``)
 
@@ -543,6 +554,9 @@ def ranking(
             init_pars=init_pars,
             fix_pars=fix_pars,
             par_bounds=par_bounds,
+            strategy=strategy,
+            maxiter=maxiter,
+            tolerance=tolerance,
             custom_fit=custom_fit,
         )
 
@@ -595,6 +609,9 @@ def ranking(
                     init_pars=init_pars_ranking,
                     fix_pars=fix_pars_ranking,
                     par_bounds=par_bounds,
+                    strategy=strategy,
+                    maxiter=maxiter,
+                    tolerance=tolerance,
                     custom_fit=custom_fit,
                 )
                 poi_val = fit_results_ranking.bestfit[poi_index]

--- a/src/cabinetry/fit/__init__.py
+++ b/src/cabinetry/fit/__init__.py
@@ -770,6 +770,9 @@ def limit(
     init_pars: Optional[List[float]] = None,
     fix_pars: Optional[List[bool]] = None,
     par_bounds: Optional[List[Tuple[float, float]]] = None,
+    strategy: Optional[Literal[0, 1, 2]] = None,
+    maxiter: Optional[int] = None,
+    tolerance: Optional[float] = None,
 ) -> LimitResults:
     """Calculates observed and expected upper parameter limits.
 
@@ -801,6 +804,14 @@ def limit(
             parameters are held constant, defaults to None (use ``pyhf`` suggestion)
         par_bounds (Optional[List[Tuple[float, float]]], optional): list of tuples with
             parameter bounds for fit, defaults to None (use ``pyhf`` suggested bounds)
+        strategy (Optional[Literal[0, 1, 2]], optional): minimization strategy used by
+            Minuit, can be 0/1/2, defaults to None (then uses ``pyhf`` default behavior
+            of strategy 0 with user-provided gradients and 1 otherwise)
+        maxiter (Optional[int], optional): allowed number of calls for minimization,
+            defaults to None (use ``pyhf`` default of 100,000)
+        tolerance (Optional[float]), optional): tolerance for convergence, for details
+            see ``iminuit.Minuit.tol`` (uses EDM < 0.002*tolerance), defaults to
+            None (use ``iminuit`` default of 0.1)
 
     Raises:
         ValueError: if no POI is found
@@ -811,7 +822,12 @@ def limit(
         LimitResults: observed and expected limits, CLs values, and scanned points
     """
     _, initial_optimizer = pyhf.get_backend()  # store initial optimizer settings
-    pyhf.set_backend(pyhf.tensorlib, pyhf.optimize.minuit_optimizer(verbose=1))
+    pyhf.set_backend(
+        pyhf.tensorlib,
+        pyhf.optimize.minuit_optimizer(
+            verbose=1, strategy=strategy, maxiter=maxiter, tolerance=tolerance
+        ),
+    )
 
     # use POI given by kwarg, fall back to POI specified in model
     poi_index = model_utils._poi_index(model, poi_name=poi_name)

--- a/tests/fit/test_fit.py
+++ b/tests/fit/test_fit.py
@@ -860,3 +860,29 @@ def test_significance(example_spec_with_background):
             },
         )
     ]
+
+    # default strategy/maxiter/tolerance
+    with mock.patch("pyhf.set_backend") as mock_backend:
+        fit.significance(model, data)
+    # setting to numpy
+    assert mock_backend.call_args_list[0][0][1].name == "minuit"
+    assert mock_backend.call_args_list[0][0][1].verbose == 1
+    assert mock_backend.call_args_list[0][0][1].strategy is None
+    assert mock_backend.call_args_list[0][0][1].maxiter is None
+    assert mock_backend.call_args_list[0][0][1].tolerance is None
+    assert mock_backend.call_args_list[0][1] == {}
+    # resetting back to scipy
+    assert mock_backend.call_args_list[1][0][1].name == "scipy"
+
+    # custom strategy/maxiter/tolerance
+    with mock.patch("pyhf.set_backend") as mock_backend:
+        fit.significance(model, data, strategy=2, maxiter=100, tolerance=0.01)
+    # setting to numpy
+    assert mock_backend.call_args_list[0][0][1].name == "minuit"
+    assert mock_backend.call_args_list[0][0][1].verbose == 1
+    assert mock_backend.call_args_list[0][0][1].strategy == 2
+    assert mock_backend.call_args_list[0][0][1].maxiter == 100
+    assert mock_backend.call_args_list[0][0][1].tolerance == 0.01
+    assert mock_backend.call_args_list[0][1] == {}
+    # resetting back to scipy
+    assert mock_backend.call_args_list[1][0][1].name == "scipy"

--- a/tests/fit/test_fit.py
+++ b/tests/fit/test_fit.py
@@ -541,7 +541,7 @@ def test_ranking(mock_fit, example_spec):
     assert np.allclose(ranking_results.postfit_up, [0.2])
     assert np.allclose(ranking_results.postfit_down, [-0.2])
 
-    # no reference results, init/fixed pars, par bounds
+    # no reference results, init/fixed pars, par bounds, strategy/maxiter/tolerance
     ranking_results = fit.ranking(
         model,
         data,
@@ -549,6 +549,9 @@ def test_ranking(mock_fit, example_spec):
         init_pars=[1.5, 1.0],
         fix_pars=[False, False],
         par_bounds=[(0, 5), (0.1, 10)],
+        strategy=2,
+        maxiter=100,
+        tolerance=0.01,
         custom_fit=True,
     )
     assert mock_fit.call_count == 9
@@ -559,19 +562,28 @@ def test_ranking(mock_fit, example_spec):
             "init_pars": [1.5, 1.0],
             "fix_pars": [False, False],
             "par_bounds": [(0, 5), (0.1, 10)],
+            "strategy": 2,
+            "maxiter": 100,
+            "tolerance": 0.01,
             "custom_fit": True,
         },
     )
-    # fits for impact
+    # fits for impact (comparing each option separately since init_pars needs allclose)
     assert mock_fit.call_args_list[-2][0] == (model, data)
     assert np.allclose(mock_fit.call_args_list[-2][1]["init_pars"], [1.5, 1.2])
     assert mock_fit.call_args_list[-2][1]["fix_pars"] == [False, True]
     assert mock_fit.call_args_list[-2][1]["par_bounds"] == [(0, 5), (0.1, 10)]
+    assert mock_fit.call_args_list[-2][1]["strategy"] == 2
+    assert mock_fit.call_args_list[-2][1]["maxiter"] == 100
+    assert mock_fit.call_args_list[-2][1]["tolerance"] == 0.01
     assert mock_fit.call_args_list[-2][1]["custom_fit"] is True
     assert mock_fit.call_args_list[-1][0] == (model, data)
     assert np.allclose(mock_fit.call_args_list[-1][1]["init_pars"], [1.5, 0.6])
     assert mock_fit.call_args_list[-1][1]["fix_pars"] == [False, True]
     assert mock_fit.call_args_list[-1][1]["par_bounds"] == [(0, 5), (0.1, 10)]
+    assert mock_fit.call_args_list[-1][1]["strategy"] == 2
+    assert mock_fit.call_args_list[-1][1]["maxiter"] == 100
+    assert mock_fit.call_args_list[-1][1]["tolerance"] == 0.01
     assert mock_fit.call_args_list[-1][1]["custom_fit"] is True
     # ranking results
     assert np.allclose(ranking_results.prefit_up, [0.0])

--- a/tests/fit/test_fit.py
+++ b/tests/fit/test_fit.py
@@ -635,6 +635,9 @@ def test_scan(mock_fit, example_spec):
         "init_pars": None,
         "fix_pars": None,
         "par_bounds": None,
+        "strategy": None,
+        "maxiter": None,
+        "tolerance": None,
         "custom_fit": False,
     }
     # fits in scan
@@ -644,10 +647,14 @@ def test_scan(mock_fit, example_spec):
             "init_pars": [scan_val, 1.1],
             "fix_pars": [True, True],
             "par_bounds": None,
+            "strategy": None,
+            "maxiter": None,
+            "tolerance": None,
             "custom_fit": False,
         }
 
-    # parameter range specified, custom fit, init/fixed pars, par bounds
+    # parameter range specified, custom fit, init/fixed pars, par bounds,
+    # strategy/maxiter/tolerance
     scan_results = fit.scan(
         model,
         data,
@@ -657,6 +664,9 @@ def test_scan(mock_fit, example_spec):
         init_pars=[1.0, 1.0],
         fix_pars=[False, False],
         par_bounds=[(0, 5), (0.1, 10)],
+        strategy=2,
+        maxiter=100,
+        tolerance=0.01,
         custom_fit=True,
     )
     expected_custom_scan = np.linspace(1.0, 1.5, 5)
@@ -666,6 +676,9 @@ def test_scan(mock_fit, example_spec):
         "init_pars": [1.5, 1.0],  # last step of scan
         "fix_pars": [True, False],
         "par_bounds": [(0, 5), (0.1, 10)],
+        "strategy": 2,
+        "maxiter": 100,
+        "tolerance": 0.01,
         "custom_fit": True,
     }
 

--- a/tests/fit/test_fit.py
+++ b/tests/fit/test_fit.py
@@ -822,7 +822,7 @@ def test_limit(example_spec_with_background, caplog):
     with mock.patch("pyhf.set_backend") as mock_backend:
         fit.limit(model, data)
     assert mock_backend.call_count == 2
-    # setting to numpy
+    # setting to minuit
     assert mock_backend.call_args_list[0][0][1].name == "minuit"
     assert mock_backend.call_args_list[0][0][1].verbose == 1
     assert mock_backend.call_args_list[0][0][1].strategy is None
@@ -836,7 +836,7 @@ def test_limit(example_spec_with_background, caplog):
     with mock.patch("pyhf.set_backend") as mock_backend:
         fit.limit(model, data, strategy=2, maxiter=100, tolerance=0.01)
     assert mock_backend.call_count == 2
-    # setting to numpy
+    # setting to minuit
     assert mock_backend.call_args_list[0][0][1].name == "minuit"
     assert mock_backend.call_args_list[0][0][1].verbose == 1
     assert mock_backend.call_args_list[0][0][1].strategy == 2
@@ -898,7 +898,7 @@ def test_significance(example_spec_with_background):
     with mock.patch("pyhf.set_backend") as mock_backend:
         fit.significance(model, data)
     assert mock_backend.call_count == 2
-    # setting to numpy
+    # setting to minuit
     assert mock_backend.call_args_list[0][0][1].name == "minuit"
     assert mock_backend.call_args_list[0][0][1].verbose == 1
     assert mock_backend.call_args_list[0][0][1].strategy is None
@@ -912,7 +912,7 @@ def test_significance(example_spec_with_background):
     with mock.patch("pyhf.set_backend") as mock_backend:
         fit.significance(model, data, strategy=2, maxiter=100, tolerance=0.01)
     assert mock_backend.call_count == 2
-    # setting to numpy
+    # setting to minuit
     assert mock_backend.call_args_list[0][0][1].name == "minuit"
     assert mock_backend.call_args_list[0][0][1].verbose == 1
     assert mock_backend.call_args_list[0][0][1].strategy == 2

--- a/tests/fit/test_fit.py
+++ b/tests/fit/test_fit.py
@@ -508,6 +508,9 @@ def test_ranking(mock_fit, example_spec):
         )
         assert np.allclose(mock_fit.call_args_list[i][1]["fix_pars"], expected_fix)
         assert mock_fit.call_args_list[i][1]["par_bounds"] is None
+        assert mock_fit.call_args_list[i][1]["strategy"] is None
+        assert mock_fit.call_args_list[i][1]["maxiter"] is None
+        assert mock_fit.call_args_list[i][1]["tolerance"] is None
         assert mock_fit.call_args_list[i][1]["custom_fit"] is False
 
     # POI removed from fit results

--- a/tests/fit/test_fit.py
+++ b/tests/fit/test_fit.py
@@ -724,7 +724,7 @@ def test_limit(example_spec_with_background, caplog):
     caplog.clear()
 
     # access negative POI values with lower bracket below zero
-    limit_results = fit.limit(model, data, bracket=(-1, 5), tolerance=0.05)
+    limit_results = fit.limit(model, data, bracket=(-1, 5), poi_tolerance=0.05)
     assert "skipping fit for Signal strength = -1.0000, setting CLs = 1" in [
         rec.message for rec in caplog.records
     ]
@@ -733,7 +733,7 @@ def test_limit(example_spec_with_background, caplog):
     caplog.clear()
 
     # convergence issues due to number of iterations
-    fit.limit(model, data, bracket=(0.1, 1), maxiter=1)
+    fit.limit(model, data, bracket=(0.1, 1), maxsteps=1)
     assert "one or more calculations did not converge, check log" in [
         rec.message for rec in caplog.records
     ]


### PR DESCRIPTION
As an extension of #330, this propagates `strategy` / `maxiter` / `tolerance` to the remaining fit API: `fit.ranking`,
`fit.scan`, `fit.limit`, `fit.significance`.

Both `limit` and `significance` use `pyhf.infer.hypotest`, which does not support passing in these settings as keyword arguments. Instead they are passed in via the minimizer configuration in the `pyhf.set_backend` call.

**breaking change:**
- renamed the former `fit.limit` keyword arguments `tolerance` and `maxiter` to `poi_tolerance` and `maxsteps` to avoid clashes with the minimizer configuration

resolves #329

```
* added minimizer configuration options to remaining fit API
* supported keyword arguments are the same as for fit.fit: strategy, maxiter and tolerance
* breaking change: fit.limit keyword arguments tolerance and maxiter renamed to poi_tolerance and maxsteps
```