### PR TITLE
build: Update lower bound of pyhf to v0.7.0rc2

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -23,7 +23,7 @@ packages = find:
 package_dir = =src
 python_requires = >=3.7
 install_requires =
-    pyhf[minuit]~=0.7.0rc1  # model.config.suggested_fixed API change
+    pyhf[minuit]~=0.7.0rc2  # model.config.suggested_fixed API change, staterror fix
     boost_histogram>=1.0.0  # subclassing with family, 1.02 for stdev scaling fix (currently not needed)
     awkward>=1.8  # _v2 API in submodule
     tabulate>=0.8.1  # multiline text


### PR DESCRIPTION
`v0.7.0rc2` fixes a regression in `staterror` introduced after `v0.6.3` and so is present in `v0.7.0rc1`.