### PR TITLE
feat: restore optimizer settings after fits

### DIFF
--- a/src/cabinetry/fit/__init__.py
+++ b/src/cabinetry/fit/__init__.py
@@ -81,6 +81,7 @@ def _fit_model_pyhf(
     Returns:
         FitResults: object storing relevant fit results
     """
+    _, initial_optimizer = pyhf.get_backend()  # store initial optimizer settings
     pyhf.set_backend(pyhf.tensorlib, pyhf.optimize.minuit_optimizer(verbose=1))
 
     # strategy=None is currently not supported in pyhf
@@ -124,7 +125,7 @@ def _fit_model_pyhf(
         best_twice_nll,
         minos_uncertainty=minos_results,
     )
-
+    pyhf.set_backend(pyhf.tensorlib, initial_optimizer)  # restore optimizer settings
     return fit_results
 
 
@@ -174,6 +175,7 @@ def _fit_model_custom(
     Returns:
         FitResults: object storing relevant fit results
     """
+    _, initial_optimizer = pyhf.get_backend()  # store initial optimizer settings
     pyhf.set_backend(pyhf.tensorlib, pyhf.optimize.minuit_optimizer(verbose=1))
 
     # use parameter settings provided in function arguments if they exist, else defaults
@@ -236,7 +238,7 @@ def _fit_model_custom(
         best_twice_nll,
         minos_uncertainty=minos_results,
     )
-
+    pyhf.set_backend(pyhf.tensorlib, initial_optimizer)  # restore optimizer settings
     return fit_results
 
 
@@ -774,6 +776,7 @@ def limit(
     Returns:
         LimitResults: observed and expected limits, CLs values, and scanned points
     """
+    _, initial_optimizer = pyhf.get_backend()  # store initial optimizer settings
     pyhf.set_backend(pyhf.tensorlib, pyhf.optimize.minuit_optimizer(verbose=1))
 
     # use POI given by kwarg, fall back to POI specified in model
@@ -984,6 +987,7 @@ def limit(
         poi_arr,
         confidence_level,
     )
+    pyhf.set_backend(pyhf.tensorlib, initial_optimizer)  # restore optimizer settings
     return limit_results
 
 
@@ -1012,6 +1016,7 @@ def significance(
     Returns:
         SignificanceResults: observed and expected p-values and significances
     """
+    _, initial_optimizer = pyhf.get_backend()  # store initial optimizer settings
     pyhf.set_backend(pyhf.tensorlib, pyhf.optimize.minuit_optimizer(verbose=1))
 
     log.info("calculating discovery significance")
@@ -1044,4 +1049,5 @@ def significance(
     significance_results = SignificanceResults(
         obs_p_val, obs_significance, exp_p_val, exp_significance
     )
+    pyhf.set_backend(pyhf.tensorlib, initial_optimizer)  # restore optimizer settings
     return significance_results

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -193,7 +193,7 @@ def test_integration(tmp_path, ntuple_creator, caplog):
     assert np.allclose(
         prediction_postfit.total_stdev_model_channels,
         [[41.043814, 45.814417, 20.439575]],
-        atol=2e-3,
+        atol=5e-3,
     )
     _ = cabinetry.visualize.data_mc(prediction_postfit, data, close_figure=True)
 


### PR DESCRIPTION
When performing fits via the `fit` API (e.g. MLEs or `pyhf.infer.hypotest` via `fit.limit` / `fit.significance`), the optimizer is set to Minuit by `cabinetry` via `pyhf.set_backend`. Previously it just stayed this way, but now it instead gets set back to the initial settings (e.g. back to `scipy`, which is the `pyhf` default).

Now that the second RC for `pyhf` 0.7.0 is out, the integration test tolerance has to be slightly relaxed for CI to pass. Unclear why #361 is not affected by this. Locally a change in result bisects to https://github.com/scikit-hep/pyhf/pull/1919, but the difference is so small that it likely is down to floating point differences amplifying in the post-fit yield uncertainty calculation.

```
* restore original pyhf optimizer settings after fits (for which Minuit is used by cabinetry)
* slightly relax tolerance in integration test
```