### PR TITLE
feat: post-fit Asimov data generation

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 -   repo: https://github.com/psf/black
-    rev: 22.6.0
+    rev: 22.8.0
     hooks:
     -   id: black
 -   repo: https://github.com/pre-commit/mirrors-mypy


### PR DESCRIPTION
Extending the `model_utils.asimov_data` API to allow feeding in a `FitResults` object to create post-fit Asimov datasets (with auxiliary data set to the best-fit values, such that subsequent fits to that dataset reproduce the best-fit values used to create the dataset). New `poi_name` and `poi_value` keyword arguments allow setting a POI to a specific value.

```
* model_utils.asimov_data supports post-fit Asimov dataset generation via new keyword argument fit_results
* added support for custom POI values in Asimov dataset generation
* updated pre-commit
```