### PR TITLE
fix: set POI for limit calculations via dedicated pyhf API

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -51,7 +51,7 @@ jobs:
         python example.py
     - name: Install pyhf backends
       run: |
-        python -m pip install .[pyhf_backends]  # install pyhf backends
+        python -m pip install pyhf[backends]@git+https://github.com/scikit-hep/pyhf.git@master  # install pyhf backends
     - name: Test with pytest and generate coverage report
       if: matrix.python-version == '3.7'
       run: |

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -51,7 +51,7 @@ jobs:
         python example.py
     - name: Install pyhf backends
       run: |
-        python -m pip install pyhf[backends]@git+https://github.com/scikit-hep/pyhf.git@master  # install pyhf backends
+        python -m pip install .[pyhf_backends]  # install pyhf backends
     - name: Test with pytest and generate coverage report
       if: matrix.python-version == '3.7'
       run: |

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,7 +23,7 @@ packages = find:
 package_dir = =src
 python_requires = >=3.7
 install_requires =
-    pyhf[minuit]~=0.7.0rc2  # model.config.suggested_fixed API change, staterror fix
+    pyhf[minuit] @ git+https://github.com/scikit-hep/pyhf.git  # model.config.suggested_fixed API change, staterror fix
     boost_histogram>=1.0.0  # subclassing with family, 1.02 for stdev scaling fix (currently not needed)
     awkward>=1.8  # _v2 API in submodule
     tabulate>=0.8.1  # multiline text

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,7 +23,7 @@ packages = find:
 package_dir = =src
 python_requires = >=3.7
 install_requires =
-    pyhf[minuit] @ git+https://github.com/scikit-hep/pyhf.git  # model.config.suggested_fixed API change, staterror fix
+    pyhf[minuit]~=0.7.0rc4  # model.config.suggested_fixed API change, staterror fix, set_poi(None)
     boost_histogram>=1.0.0  # subclassing with family, 1.02 for stdev scaling fix (currently not needed)
     awkward>=1.8  # _v2 API in submodule
     tabulate>=0.8.1  # multiline text

--- a/src/cabinetry/fit/__init__.py
+++ b/src/cabinetry/fit/__init__.py
@@ -780,7 +780,7 @@ def limit(
     Brent's algorithm is used to automatically determine POI values to be tested. The
     desired confidence level can be configured, and defaults to 95%. In order to support
     setting the POI directly without model recompilation, this temporarily changes the
-    POI index and name in the model configuration.
+    POI name in the model configuration.
 
     Args:
         model (pyhf.pdf.Model): model to use in fits
@@ -834,12 +834,10 @@ def limit(
     if poi_index is None:
         raise ValueError("no POI specified, cannot calculate limit")
 
-    # set POI index / name in model config to desired value, hypotest will pick this up
-    # save original values to reset model later
-    original_model_poi_index = model.config.poi_index
+    # set POI name in model config to desired value, hypotest will pick this up
+    # save original value to reset model later
     original_model_poi_name = model.config.poi_name
-    model.config.poi_index = poi_index
-    model.config.poi_name = model.config.par_names()[poi_index]
+    model.config.set_poi(model.config.par_names()[poi_index])
 
     # show two decimals only if confidence level in percent is not an integer
     cl_label = (
@@ -866,9 +864,8 @@ def limit(
     if bracket is None:
         bracket = (bracket_left_default, bracket_right_default)
     elif bracket[0] == bracket[1]:
-        # set POI index / name in model back to their original values
-        model.config.poi_index = original_model_poi_index
-        model.config.poi_name = original_model_poi_name
+        # set POI in model back to original value
+        model.config.set_poi(original_model_poi_name)
         raise ValueError(f"the two bracket values must not be the same: {bracket}")
 
     cache_CLs: Dict[float, tuple] = {}  # cache storing all relevant results
@@ -966,9 +963,8 @@ def limit(
                 f"CLs values at {bracket[0]:.4f} and {bracket[1]:.4f} do not bracket "
                 f"CLs={cls_target:.4f}, try a different starting bracket"
             )
-            # set POI index / name in model back to their original values
-            model.config.poi_index = original_model_poi_index
-            model.config.poi_name = original_model_poi_name
+            # set POI in model back to original value
+            model.config.set_poi(original_model_poi_name)
             raise
 
         if not res.converged:
@@ -1010,9 +1006,8 @@ def limit(
 
             bracket = (bracket_left, bracket_right)
 
-    # set POI index / name in model back to their original values
-    model.config.poi_index = original_model_poi_index
-    model.config.poi_name = original_model_poi_name
+    # set POI in model back to original values
+    model.config.set_poi(original_model_poi_name)
 
     # report all results
     log.info(f"total of {steps_total} steps to calculate all limits")

--- a/src/cabinetry/fit/__init__.py
+++ b/src/cabinetry/fit/__init__.py
@@ -780,7 +780,7 @@ def limit(
     Brent's algorithm is used to automatically determine POI values to be tested. The
     desired confidence level can be configured, and defaults to 95%. In order to support
     setting the POI directly without model recompilation, this temporarily changes the
-    POI name in the model configuration.
+    POI in the model configuration.
 
     Args:
         model (pyhf.pdf.Model): model to use in fits


### PR DESCRIPTION
#348 added the possibility to specify a custom POI via a kwarg in `fit.limit`. This was done by setting `model.config.poi_name` and `model.config.poi_index` directly, which is no longer possible after https://github.com/scikit-hep/pyhf/pull/1972 (see https://github.com/scikit-hep/pyhf/issues/1984). https://github.com/scikit-hep/pyhf/pull/1985 adds support for `None` POI values in `model.config.set_poi`, which allows that API to be used instead. This PR switches to this dedicated API to support temporarily changing the POI, which requires an update of the minimum `pyhf` version to `0.7.0rc4`.

```
* use pyhf model.config.set_poi API to support temporary POI changes in limit calculations
```