### PR TITLE
build: raise minimum required matplotlib version to 3.5.0

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -27,7 +27,7 @@ install_requires =
     boost_histogram>=1.0.0  # subclassing with family, 1.02 for stdev scaling fix (currently not needed)
     awkward>=1.8  # _v2 API in submodule
     tabulate>=0.8.1  # multiline text
-    matplotlib
+    matplotlib>=3.5.0  # layout kwarg for subplots
     typing_extensions;python_version<"3.8"  # for Literal type
     # below are direct dependencies of cabinetry, which are also included via pyhf[iminuit]
     numpy


### PR DESCRIPTION
The figure layout refactor introduced in `cabinetry` 0.5.0 requires `matplotlib` 3.5.0 or newer. Raise the minimum required version accordingly to prevent crashes with older versions.

resolves #369

```
* raise minimum required matplotlib version to 3.5.0
```