### PR TITLE
chore: updating version to 0.5.1

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = cabinetry
-version = 0.5.0
+version = 0.5.1
 author = Alexander Held
 description = design and steer profile likelihood fits
 long_description = file: README.md

--- a/src/cabinetry/__init__.py
+++ b/src/cabinetry/__init__.py
@@ -13,7 +13,7 @@ import cabinetry.visualize  # noqa: F401
 import cabinetry.workspace  # noqa: F401
 
 
-__version__ = "0.5.0"
+__version__ = "0.5.1"
 
 
 def set_logging() -> None:


### PR DESCRIPTION
Updating to version `0.5.1`. This fixes the lower bound for the `matplotlib` dependency and adopts a better sorting for nuisance parameter ranking.

```
* updating version to 0.5.1
```