### PR TITLE
refactor: correlation matrix tick label rotation and alignment

### DIFF
--- a/src/cabinetry/visualize/plot_result.py
+++ b/src/cabinetry/visualize/plot_result.py
@@ -56,11 +56,8 @@ def correlation_matrix(
 
     ax.set_xticks(np.arange(len(labels)))
     ax.set_yticks(np.arange(len(labels)))
-    ax.set_xticklabels(labels)
+    ax.set_xticklabels(labels, rotation=45, ha="right")
     ax.set_yticklabels(labels)
-    for tick in ax.get_xticklabels():
-        tick.set_rotation(45)
-        tick.set_horizontalalignment("right")
 
     fig.colorbar(im, ax=ax)
     ax.set_aspect("auto")  # to get colorbar aligned with matrix


### PR DESCRIPTION
Minor refactor: the x-axis tick labels can be rotated and aligned directly when set instead of requiring a loop.

```
* rotate and align x-axis tick labels without requiring a loop for correlation matrix visualization
```