### PR TITLE
fix: saturated likelihood evaluation with custom auxiliary data

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,7 @@ repos:
         additional_dependencies: ["numpy>=1.22", "boost-histogram>=1.0.1", "click>=8", "types-tabulate", "types-PyYAML"]
         args: ["--python-version=3.10"]
 -   repo: https://github.com/pycqa/flake8
-    rev: 5.0.4
+    rev: 6.0.0
     hooks:
     -   id: flake8
         additional_dependencies: [flake8-bugbear, flake8-import-order, flake8-print]
@@ -27,7 +27,7 @@ repos:
     -   id: pyupgrade
         args: ["--py37-plus"]
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.3.0
+    rev: v4.4.0
     hooks:
     -   id: check-added-large-files
         args: ["--maxkb=100"]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,7 @@ repos:
         additional_dependencies: ["numpy>=1.22", "boost-histogram>=1.0.1", "click>=8", "types-tabulate", "types-PyYAML"]
         args: ["--python-version=3.10"]
 -   repo: https://github.com/pycqa/flake8
-    rev: 6.0.0
+    rev: 5.0.4
     hooks:
     -   id: flake8
         additional_dependencies: [flake8-bugbear, flake8-import-order, flake8-print]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@ repos:
     hooks:
     -   id: black
 -   repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.982
+    rev: v0.991
     hooks:
     -   id: mypy
         name: mypy with Python 3.8
@@ -22,7 +22,7 @@ repos:
     -   id: flake8
         additional_dependencies: [flake8-bugbear, flake8-import-order, flake8-print]
 -   repo: https://github.com/asottile/pyupgrade
-    rev: v3.1.0
+    rev: v3.2.2
     hooks:
     -   id: pyupgrade
         args: ["--py37-plus"]

--- a/src/cabinetry/fit/__init__.py
+++ b/src/cabinetry/fit/__init__.py
@@ -384,7 +384,9 @@ def _goodness_of_fit(
 
         # need to obtain the parameters that maximize the constraint term
         # (will not match suggested_init() when auxdata is custom)
-        best_pars = model_utils._parameters_maximizing_constraints(model, aux_data)
+        best_pars = model_utils._parameters_maximizing_constraints(
+            model, pyhf.tensorlib.tolist(aux_data)
+        )
 
         # constraint term: log Gaussian(aux_data|parameters) etc.
         constraint_ll = pyhf.tensorlib.to_numpy(

--- a/src/cabinetry/fit/__init__.py
+++ b/src/cabinetry/fit/__init__.py
@@ -384,7 +384,7 @@ def _goodness_of_fit(
 
         # need to obtain the parameters that maximize the constraint term
         # (will not match suggested_init() when auxdata is custom)
-        best_pars = model_utils._parameters_maximizing_constraints(
+        best_pars = model_utils._parameters_maximizing_constraint_term(
             model, pyhf.tensorlib.tolist(aux_data)
         )
 

--- a/src/cabinetry/model_utils.py
+++ b/src/cabinetry/model_utils.py
@@ -710,6 +710,8 @@ def _parameters_maximizing_constraint_term(
 ) -> List[float]:
     """Returns parameters maximizing the constraint term for the given auxiliary data.
 
+    Parameters without an associated constraint term are set to their initial value.
+
     Args:
         model (pyhf.pdf.Model): model to use for constraint term evaluation
         aux_data (List[float]): auxiliary data for which the constraint term should be

--- a/src/cabinetry/model_utils.py
+++ b/src/cabinetry/model_utils.py
@@ -743,7 +743,7 @@ def _parameters_maximizing_constraint_term(
                 ]
                 i_poisson += n_params
             else:
-                rescale_factors = [1] * n_params  # no rescaling by default
+                rescale_factors = [1.0] * n_params  # no rescaling by default
 
             best_pars += list(
                 np.asarray(aux_data[i_aux : i_aux + n_params]) / rescale_factors

--- a/src/cabinetry/model_utils.py
+++ b/src/cabinetry/model_utils.py
@@ -705,7 +705,19 @@ def _modifier_map(
     return modifier_map
 
 
-def _parameters_maximizing_constraints(model, aux_data):
+def _parameters_maximizing_constraints(
+    model: pyhf.pdf.Model, aux_data: List[float]
+) -> List[float]:
+    """Returns parameters maximizing the constraint term for the given auxiliary data.
+
+    Args:
+        model (pyhf.pdf.Model): model to use for constraint term evaluation
+        aux_data (List[float]): auxiliary data for which the constraint term should be
+            maximized
+
+    Returns:
+        List[float]: parameters maximizing the model constraint term
+    """
     # need to obtain the parameters that maximize the constraint term
     i_aux = 0
     i_poisson = 0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -311,6 +311,78 @@ def example_spec_lumi():
     return spec
 
 
+@pytest.fixture
+def example_spec_modifiers():
+    spec = {
+        "channels": [
+            {
+                "name": "SR",
+                "samples": [
+                    {
+                        "data": [35.0, 30.0],
+                        "modifiers": [
+                            {
+                                "data": None,
+                                "name": "mu",
+                                "type": "normfactor",
+                            },
+                            {
+                                "data": None,
+                                "name": "mu_shapefactor",
+                                "type": "shapefactor",
+                            },
+                            {
+                                "data": {"hi": 0.8, "lo": 1.2},
+                                "name": "normsys",
+                                "type": "normsys",
+                            },
+                            {
+                                "data": {
+                                    "hi_data": [36.0, 31.0],
+                                    "lo_data": [34.0, 29.0],
+                                },
+                                "name": "histosys",
+                                "type": "histosys",
+                            },
+                            {
+                                "data": [1.0, 2.0],
+                                "name": "staterror_SR",
+                                "type": "staterror",
+                            },
+                            {
+                                "data": [1.0, 2.0],
+                                "name": "shapesys_SR",
+                                "type": "shapesys",
+                            },
+                            {"data": None, "name": "lumi", "type": "lumi"},
+                        ],
+                        "name": "Signal",
+                    }
+                ],
+            }
+        ],
+        "measurements": [
+            {
+                "config": {
+                    "parameters": [
+                        {
+                            "auxdata": [1.0],
+                            "inits": [1.0],
+                            "name": "lumi",
+                            "sigmas": [0.02],
+                        }
+                    ],
+                    "poi": "mu",
+                },
+                "name": "lumi modifier",
+            }
+        ],
+        "observations": [{"data": [35, 30], "name": "SR"}],
+        "version": "1.0.0",
+    }
+    return spec
+
+
 # code below allows marking tests as slow and adds --runslow to run them
 # implemented following https://docs.pytest.org/en/6.2.x/example/simple.html
 def pytest_addoption(parser):

--- a/tests/fit/test_fit.py
+++ b/tests/fit/test_fit.py
@@ -324,7 +324,7 @@ def test__run_minos(caplog):
 
 @mock.patch("cabinetry.model_utils.unconstrained_parameter_count", return_value=1)
 @mock.patch(
-    "cabinetry.model_utils._parameters_maximizing_constraints",
+    "cabinetry.model_utils._parameters_maximizing_constraint_term",
     side_effect=[
         [1.0, 1.0, 1.0, 1.0],  # for example_spec_multibin
         [1.0, 0.9, 1.1, 0.8],  # for custom aux

--- a/tests/test_model_utils.py
+++ b/tests/test_model_utils.py
@@ -515,3 +515,26 @@ def test_modifier_map(example_spec):
         ("Signal Region", "Signal", "Signal strength"): ["normfactor"],
     }
     assert modifier_map[("a", "b", "c")] == []
+
+
+def test__parameters_maximizing_constraints(
+    example_spec, example_spec_no_aux, example_spec_modifiers
+):
+    # staterror, custom auxdata value
+    model = pyhf.Workspace(example_spec).model()
+    best_pars = model_utils._parameters_maximizing_constraints(model, [1.1])
+    assert np.allclose(best_pars, [1.0, 1.1])
+
+    # no auxdata
+    model = pyhf.Workspace(example_spec_no_aux).model()
+    best_pars = model_utils._parameters_maximizing_constraints(model, [])
+    assert np.allclose(best_pars, [1.0])
+
+    # all modifiers (including Poisson constraint for shapesys), custom auxdata values
+    # order: histosys, lumi, normfactor, normsys, shapefactor (2 bins),
+    # shapesys (2 bins), staterror (2 bins)
+    model = pyhf.Workspace(example_spec_modifiers).model()
+    best_pars = model_utils._parameters_maximizing_constraints(
+        model, [0.1, 1.1, 0.2, 1531.25, 281.25, 0.9, 0.8]
+    )
+    assert np.allclose(best_pars, [0.1, 1.1, 1.0, 0.2, 1.0, 1.0, 1.25, 1.25, 0.9, 0.8])

--- a/tests/test_model_utils.py
+++ b/tests/test_model_utils.py
@@ -517,24 +517,24 @@ def test_modifier_map(example_spec):
     assert modifier_map[("a", "b", "c")] == []
 
 
-def test__parameters_maximizing_constraints(
+def test__parameters_maximizing_constraint_term(
     example_spec, example_spec_no_aux, example_spec_modifiers
 ):
     # staterror, custom auxdata value
     model = pyhf.Workspace(example_spec).model()
-    best_pars = model_utils._parameters_maximizing_constraints(model, [1.1])
+    best_pars = model_utils._parameters_maximizing_constraint_term(model, [1.1])
     assert np.allclose(best_pars, [1.0, 1.1])
 
     # no auxdata
     model = pyhf.Workspace(example_spec_no_aux).model()
-    best_pars = model_utils._parameters_maximizing_constraints(model, [])
+    best_pars = model_utils._parameters_maximizing_constraint_term(model, [])
     assert np.allclose(best_pars, [1.0])
 
     # all modifiers (including Poisson constraint for shapesys), custom auxdata values
     # order: histosys, lumi, normfactor, normsys, shapefactor (2 bins),
     # shapesys (2 bins), staterror (2 bins)
     model = pyhf.Workspace(example_spec_modifiers).model()
-    best_pars = model_utils._parameters_maximizing_constraints(
+    best_pars = model_utils._parameters_maximizing_constraint_term(
         model, [0.1, 1.1, 0.2, 1531.25, 281.25, 0.9, 0.8]
     )
     assert np.allclose(best_pars, [0.1, 1.1, 1.0, 0.2, 1.0, 1.0, 1.25, 1.25, 0.9, 0.8])


### PR DESCRIPTION
The evaluation of the constraint term in the saturated likelihood for goodness-of-fit testing previously used the suggested parameter values for a given model. Those maximize the constraint term only if the auxiliary data used in the fit for which the GOF is being evaluated corresponds to the default `model.config.auxdata`.

This fixes the construction of the parameter values used in the constraint term evaluation to ensure the saturated likelihood is correctly evaluated. Parameter values can be picked up from auxiliary data if they correspond to modifiers with associated constraints, with scaling required for Poisson terms. Other parameter values (corresponding to free-floating parameters) can be picked up from `model.config.suggested_init()`, but do not matter for the constraint term likelihood regardless.

This requires #380 for CI to pass due to #379. 

```
* fix: correctly evaluate the constraint term for the saturated likelihood with best-fit parameters
* updated pre-commit
```

resolves #377 