### PR TITLE
build: temporarily pin flake8<6

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ extras_require["test"] = sorted(
             "pytest-cov>=2.6.1",  # no_cover support
             "pydocstyle",
             "check-manifest",
-            "flake8",
+            "flake8<6",
             "flake8-bugbear",
             "flake8-import-order",
             "flake8-print",


### PR DESCRIPTION
`flake8-import-order` is incompatible with `flake8` version `6.0.0` at the moment, see #379. Temporarily pin to avoid issues and then remove pin once everything is compatible again.

```
* temporarily pin flake8<6 due to incompatibility with flake8-import-order
```