### PR TITLE
style: apply Black's 2023 style

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 -   repo: https://github.com/psf/black
-    rev: 22.10.0
+    rev: 22.12.0
     hooks:
     -   id: black
 -   repo: https://github.com/pre-commit/mirrors-mypy
@@ -22,7 +22,7 @@ repos:
     -   id: flake8
         additional_dependencies: [flake8-bugbear, flake8-import-order, flake8-print]
 -   repo: https://github.com/asottile/pyupgrade
-    rev: v3.2.2
+    rev: v3.3.1
     hooks:
     -   id: pyupgrade
         args: ["--py37-plus"]

--- a/src/cabinetry/cli/__init__.py
+++ b/src/cabinetry/cli/__init__.py
@@ -344,9 +344,7 @@ def data_mc(
     help='folder to save figures to (default: "figures")',
 )
 def modifier_grid(
-    ws_spec: io.TextIOWrapper,
-    split_by_sample: bool,
-    figfolder: str,
+    ws_spec: io.TextIOWrapper, split_by_sample: bool, figfolder: str
 ) -> None:
     """Visualizes modifier structure of a model.
 

--- a/src/cabinetry/model_utils.py
+++ b/src/cabinetry/model_utils.py
@@ -389,10 +389,7 @@ def yield_stdev(
                 tuple(parameters),
                 tuple(uncertainty),
                 corr_mat.data.tobytes(),
-            ): (
-                total_stdev_per_bin,
-                total_stdev_per_channel,
-            )
+            ): (total_stdev_per_bin, total_stdev_per_channel)
         }
     )
 

--- a/src/cabinetry/templates/builder.py
+++ b/src/cabinetry/templates/builder.py
@@ -345,6 +345,7 @@ class _Builder:
         Returns:
             cabinetry.route.ProcessorFunc: wrapped template builder
         """
+
         # decorating this with functools.wraps will keep the name of the wrapped
         # function the same, however the signature of the wrapped function is slightly
         # different (the return value becomes None)

--- a/src/cabinetry/visualize/__init__.py
+++ b/src/cabinetry/visualize/__init__.py
@@ -528,8 +528,7 @@ def ranking(
 
     # sort parameters by decreasing maximum post-fit impact
     max_postfit_impact = np.maximum(
-        np.abs(ranking_results.postfit_up),
-        np.abs(ranking_results.postfit_down),
+        np.abs(ranking_results.postfit_up), np.abs(ranking_results.postfit_down)
     )
 
     # get indices to sort by decreasing impact

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -321,11 +321,7 @@ def example_spec_modifiers():
                     {
                         "data": [35.0, 30.0],
                         "modifiers": [
-                            {
-                                "data": None,
-                                "name": "mu",
-                                "type": "normfactor",
-                            },
+                            {"data": None, "name": "mu", "type": "normfactor"},
                             {
                                 "data": None,
                                 "name": "mu_shapefactor",

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -16,11 +16,7 @@ def test_load(mock_validation):
 
 def test_validate():
     config_valid = {
-        "General": {
-            "Measurement": "",
-            "HistogramFolder": "",
-            "InputPath": "",
-        },
+        "General": {"Measurement": "", "HistogramFolder": "", "InputPath": ""},
         "Regions": [{"Name": "", "Filter": "", "Variable": "", "Binning": [0, 1]}],
         "Samples": [{"Name": "", "Tree": "", "Data": True}],
         "NormFactors": [{"Name": ""}],
@@ -29,11 +25,7 @@ def test_validate():
 
     # not exactly one data sample
     config_multiple_data_samples = {
-        "General": {
-            "Measurement": "",
-            "HistogramFolder": "",
-            "InputPath": "",
-        },
+        "General": {"Measurement": "", "HistogramFolder": "", "InputPath": ""},
         "Regions": [{"Name": "", "Filter": "", "Variable": "", "Binning": [0, 1]}],
         "Samples": [{"Name": "", "Tree": ""}],
         "NormFactors": [{"Name": ""}],

--- a/tests/test_model_utils.py
+++ b/tests/test_model_utils.py
@@ -79,9 +79,7 @@ def test_asimov_data(example_spec):
     # pre-fit Asimov, custom POI name + value
     assert np.allclose(
         model_utils.asimov_data(
-            model,
-            poi_name="staterror_Signal-Region[0]",
-            poi_value=1.1,
+            model, poi_name="staterror_Signal-Region[0]", poi_value=1.1
         ),
         [113.96, 1.1],  # 2*51.8*1.1
     )

--- a/tests/visualize/test_visualize.py
+++ b/tests/visualize/test_visualize.py
@@ -597,8 +597,7 @@ def test_limit(mock_draw):
 @mock.patch(
     "cabinetry.model_utils._modifier_map",
     return_value=defaultdict(
-        list,
-        {("Signal Region", "Signal", "Signal strength"): ["normfactor"]},
+        list, {("Signal Region", "Signal", "Signal strength"): ["normfactor"]}
     ),
 )
 def test_modifier_grid(mock_map, mock_draw, example_spec, caplog):


### PR DESCRIPTION
Applying `black`'s 2023 style via its [23.1a1](https://github.com/psf/black/releases/tag/23.1a1) release. The changes are compatible with prior versions of `black`, so this should not be causing issues in CI. Also running `--skip-magic-trailing-comma` once to adjust cases where expressions may previously have been longer but now can be collapsed back into one line.

```
* apply Black's 2023 style
* updated pre-commit
```