### PR TITLE
build: revert flake8 pin

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -64,7 +64,8 @@ count = True
 statistics = True
 import-order-style = google
 application-import-names = cabinetry, utils
-extend-ignore = E203  # whitespace before ':'
+# ignore whitespace before ':'
+extend-ignore = E203
 # ignore print statements in example
 per-file-ignores =
     example.py: T

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ extras_require["test"] = sorted(
             "pytest-cov>=2.6.1",  # no_cover support
             "pydocstyle",
             "check-manifest",
-            "flake8<6",
+            "flake8",
             "flake8-bugbear",
             "flake8-import-order",
             "flake8-print",


### PR DESCRIPTION
Resolves #379: the pin `flake8<6` introduced temporarily in #380 can be removed, given that a compatible `flake8-import-order` version now exists.

```
* remove temporary flake8 pin
* fix formatting issue with flake8 extend-ignore setting
```