### PR TITLE
chore: fix editor autocompletion

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,7 @@ repos:
         additional_dependencies: ["numpy>=1.22", "boost-histogram>=1.0.1", "click>=8", "types-tabulate", "types-PyYAML"]
         args: ["--python-version=3.10"]
 -   repo: https://github.com/pycqa/flake8
-    rev: 5.0.4
+    rev: 6.0.0
     hooks:
     -   id: flake8
         additional_dependencies: [flake8-bugbear, flake8-import-order, flake8-print]
@@ -33,7 +33,7 @@ repos:
         args: ["--maxkb=100"]
     -   id: trailing-whitespace
 -   repo: https://github.com/pycqa/pydocstyle
-    rev: 6.1.1
+    rev: 6.2.3
     hooks:
     -   id: pydocstyle
         # configuration duplicated in setup.cfg

--- a/src/cabinetry/__init__.py
+++ b/src/cabinetry/__init__.py
@@ -1,16 +1,38 @@
 """The cabinetry library."""
 
 import logging
+from typing import List
 
-import cabinetry.configuration  # noqa: F401
-import cabinetry.fit  # noqa: F401
-import cabinetry.model_utils  # noqa: F401
-import cabinetry.route  # noqa: F401
-import cabinetry.smooth  # noqa: F401
-import cabinetry.tabulate  # noqa: F401
-import cabinetry.templates  # noqa: F401
-import cabinetry.visualize  # noqa: F401
-import cabinetry.workspace  # noqa: F401
+import cabinetry.configuration as configuration  # noqa: F401
+import cabinetry.fit as fit  # noqa: F401
+import cabinetry.histo as histo  # noqa: F401
+import cabinetry.model_utils as model_utils  # noqa: F401
+import cabinetry.route as route  # noqa: F401
+import cabinetry.smooth as smooth  # noqa: F401
+import cabinetry.tabulate as tabulate  # noqa: F401
+import cabinetry.templates as templates  # noqa: F401
+import cabinetry.visualize as visualize  # noqa: F401
+import cabinetry.workspace as workspace  # noqa: F401
+
+
+__all__ = [
+    "__version__",
+    "set_logging",
+    "configuration",
+    "fit",
+    "histo",
+    "model_utils",
+    "route",
+    "smooth",
+    "tabulate",
+    "templates",
+    "visualize",
+    "workspace",
+]
+
+
+def __dir__() -> List[str]:
+    return __all__
 
 
 __version__ = "0.5.1"


### PR DESCRIPTION
This fixes code autocompletion for vscode (IntelliSense) by importing the `cabinetry` components differently in the top-level `__init__.py`. Previously they were accessible only via `cabinetry.cabinetry`. `histo` was previously  missing here and is also added, and an appropriate top-level `__all__` is also defined.

```
* fixed editor autocompletion by appropriately importing cabinetry components
* added top-level __all__
* updated pre-commit
```