### PR TITLE
fix: temporarily pin typeguard<3

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,10 +1,10 @@
 repos:
 -   repo: https://github.com/psf/black
-    rev: 22.12.0
+    rev: 23.1.0
     hooks:
     -   id: black
 -   repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.991
+    rev: v1.1.1
     hooks:
     -   id: mypy
         name: mypy with Python 3.8
@@ -33,13 +33,13 @@ repos:
         args: ["--maxkb=100"]
     -   id: trailing-whitespace
 -   repo: https://github.com/pycqa/pydocstyle
-    rev: 6.2.3
+    rev: 6.3.0
     hooks:
     -   id: pydocstyle
         # configuration duplicated in setup.cfg
         args: ["--match=(?!setup|example).*\\.py'", "--match-dir='^(?!(tests|utils|docs)).*'", "--convention=google"]
 -   repo: https://github.com/codespell-project/codespell
-    rev: v2.2.2
+    rev: v2.2.4
     hooks:
     -   id: codespell
         args: ["-L", "hist", "src", "tests", "utils", "docs/*rst"]

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ extras_require["test"] = sorted(
             "mypy",
             "types-tabulate",
             "types-PyYAML",
-            "typeguard~=2.13",  # typing.NamedTuple compatibility in Python 3.7
+            "typeguard~=2.13",  # typing.NamedTuple in Python 3.7, cabinetry#391
             "black",
         ]
     )

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ extras_require["test"] = sorted(
             "mypy",
             "types-tabulate",
             "types-PyYAML",
-            "typeguard>=2.13.0",  # typing.NamedTuple compatibility in Python 3.7
+            "typeguard~=2.13",  # typing.NamedTuple compatibility in Python 3.7
             "black",
         ]
     )


### PR DESCRIPTION
`typeguard` version 3.0 introduced CI failures in the nightly tests, see #391. Temporarily pin `typeguard<3` to keep using the older version in CI. Eventually the newer version should be adopted in order to take advantage of the additional issues it can catch.

```
* temporarily pin typeguard<3 to fix CI
* updated pre-commit
```