### PR TITLE
test: add test for builtin dir()

### DIFF
--- a/tests/test_cabinetry.py
+++ b/tests/test_cabinetry.py
@@ -3,6 +3,10 @@ import logging
 import cabinetry
 
 
+def test___dir__():
+    assert dir(cabinetry) == sorted(cabinetry.__all__)
+
+
 def test_set_logging(caplog):
     log = logging.getLogger("cabinetry")
 


### PR DESCRIPTION
#386 added `__all__` and `dir()` for `cabinetry`, but did not include a test and coverage for that, which is added by this PR.

```
* test and cover dir(cabinetry)
```