### PR TITLE
fix: handle negative model predictions in visualizations

### DIFF
--- a/src/cabinetry/visualize/plot_model.py
+++ b/src/cabinetry/visualize/plot_model.py
@@ -320,9 +320,9 @@ def templates(
     # x positions for lines drawn showing the template distributions
     line_x = [y for y in bin_edges for _ in range(2)][1:-1]
 
-    neg_nom_bins = False  # negative bins present in nominal histogram
+    neg_nom_bin = False  # negative bin(s) present in nominal histogram
     if np.any(nominal_histo["yields"] < 0.0):
-        neg_nom_bins = True
+        neg_nom_bin = True
         log.warning(
             f"{label} nominal histogram yield has negative bin(s): "
             f"{nominal_histo['yields'].tolist()}, taking absolute value for "
@@ -412,7 +412,7 @@ def templates(
     ax2.set_xlim([bin_edges[0], bin_edges[-1]])
     ax2.set_ylim([0.5, 1.5])
     ax2.set_xlabel(variable)
-    ax2.set_ylabel(f"variation / {'nominal' if not neg_nom_bins else 'abs(nominal)'}")
+    ax2.set_ylabel(f"variation / {'nominal' if not neg_nom_bin else 'abs(nominal)'}")
     ax2.set_yticks([0.5, 0.75, 1.0, 1.25, 1.5])
     ax2.set_yticklabels([0.5, 0.75, 1.0, 1.25, ""])
     ax2.tick_params(axis="both", which="major", pad=8)

--- a/src/cabinetry/visualize/plot_model.py
+++ b/src/cabinetry/visualize/plot_model.py
@@ -145,12 +145,15 @@ def data_mc(
     n_zero_pred = sum(total_yield == 0.0)  # number of bins with zero predicted yields
     if n_zero_pred > 0:
         log.warning(
-            f"predicted yield is zero in {n_zero_pred} bin(s), excluded from ratio plot"
+            f"predicted yield is zero in {n_zero_pred} bin(s),\
+            excluded from ratio plot"
         )
     nonzero_model_yield = total_yield != 0.0
 
     if np.any(total_yield < 0.0):
-        raise ValueError(f"{label} total yield {total_yield.tolist()} has negative bin(s)")
+        raise ValueError(
+            f"{label} total yield {total_yield.tolist()} has negative bin(s)"
+        )
 
     # add uncertainty band around y=1
     rel_mc_unc = total_model_unc / total_yield
@@ -355,12 +358,16 @@ def templates(
 
             if np.any(nominal_histo["yields"] < 0.0):
                 log.warning(
-                    f"{label} nominal histo yield {nominal_histo['yields'].tolist()} has negative bin(s), taking absolute value for yerr on template ratio plot uncertainty"
+                    f"{label} nominal histo yield {nominal_histo['yields'].tolist()}\
+                        has negative bin(s), taking absolute value for yerr on\
+                        template ratio plot uncertainty"
                 )
-                template_ratio_plot_unc = template["stdev"] / np.abs(nominal_histo["yields"])
+                template_ratio_plot_unc = template["stdev"] / np.abs(
+                    nominal_histo["yields"]
+                )
             else:
                 template_ratio_plot_unc = template["stdev"] / nominal_histo["yields"]
- 
+
             ax2.plot(line_x, line_y, color=color, linestyle=linestyle)
             ax2.errorbar(
                 bin_centers,

--- a/src/cabinetry/visualize/plot_model.py
+++ b/src/cabinetry/visualize/plot_model.py
@@ -149,6 +149,9 @@ def data_mc(
         )
     nonzero_model_yield = total_yield != 0.0
 
+    if np.any(total_yield < 0.0):
+        raise ValueError(f"{label} total yield {total_yield.tolist()} has negative bin(s)")
+
     # add uncertainty band around y=1
     rel_mc_unc = total_model_unc / total_yield
     # do not show band in bins where total model yield is 0
@@ -350,11 +353,19 @@ def templates(
             template_ratio_plot = template["yields"] / nominal_histo["yields"]
             line_y = [y for y in template_ratio_plot for _ in range(2)]
 
+            if np.any(nominal_histo["yields"] < 0.0):
+                log.warning(
+                    f"{label} nominal histo yield {nominal_histo['yields'].tolist()} has negative bin(s), taking absolute value for yerr on template ratio plot uncertainty"
+                )
+                template_ratio_plot_unc = template["stdev"] / np.abs(nominal_histo["yields"])
+            else:
+                template_ratio_plot_unc = template["stdev"] / nominal_histo["yields"]
+ 
             ax2.plot(line_x, line_y, color=color, linestyle=linestyle)
             ax2.errorbar(
                 bin_centers,
                 template_ratio_plot,
-                yerr=template["stdev"] / nominal_histo["yields"],
+                yerr=template_ratio_plot_unc,
                 fmt="none",
                 color=color,
             )

--- a/src/cabinetry/visualize/plot_model.py
+++ b/src/cabinetry/visualize/plot_model.py
@@ -145,8 +145,7 @@ def data_mc(
     n_zero_pred = sum(total_yield == 0.0)  # number of bins with zero predicted yields
     if n_zero_pred > 0:
         log.warning(
-            f"predicted yield is zero in {n_zero_pred} bin(s),\
-            excluded from ratio plot"
+            f"predicted yield is zero in {n_zero_pred} bin(s), excluded from ratio plot"
         )
     nonzero_model_yield = total_yield != 0.0
 

--- a/src/cabinetry/visualize/plot_model.py
+++ b/src/cabinetry/visualize/plot_model.py
@@ -52,6 +52,9 @@ def data_mc(
             saving it, defaults to False (enable when producing many figures to avoid
             memory issues, prevents rendering in notebooks)
 
+    Raises:
+        ValueError: when total model yield is negative in any bin
+
     Returns:
         matplotlib.figure.Figure: the data/MC figure
     """


### PR DESCRIPTION
related to issue https://github.com/scikit-hep/cabinetry/issues/388.

Tried `python -m pytest`, did not pass all tests even before modifying anything. No additional errors though after the fix and tested with samples mantioned in issue https://github.com/scikit-hep/cabinetry/issues/388.