### PR TITLE
feat: command line interface for yield tables

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 -   repo: https://github.com/psf/black
-    rev: 23.1.0
+    rev: 23.3.0
     hooks:
     -   id: black
 -   repo: https://github.com/pre-commit/mirrors-mypy

--- a/src/cabinetry/cli/__init__.py
+++ b/src/cabinetry/cli/__init__.py
@@ -13,6 +13,7 @@ from cabinetry import __version__
 from cabinetry import configuration as cabinetry_configuration
 from cabinetry import fit as cabinetry_fit
 from cabinetry import model_utils as cabinetry_model_utils
+from cabinetry import tabulate as cabinetry_tabulate
 from cabinetry import templates as cabinetry_templates
 from cabinetry import visualize as cabinetry_visualize
 from cabinetry import workspace as cabinetry_workspace
@@ -334,6 +335,47 @@ def data_mc(
 @click.command()
 @click.argument("ws_spec", type=click.File("r"))
 @click.option(
+    "--postfit", is_flag=True, help="show post-fit model (default: pre-fit model)"
+)
+@click.option(
+    "--tablefolder",
+    default="tables",
+    help='folder to save tables to (default: "tables")',
+)
+@click.option(
+    "--tablefmt",
+    default="simple",
+    help='format in which to save the table (default: "simple")',
+)
+def yields(
+    ws_spec: io.TextIOWrapper,
+    postfit: bool,
+    tablefmt: str,
+    tablefolder: str,
+) -> None:
+    """Creates yield tables of fit model and observed data.
+
+    WS_SPEC: path to workspace
+    """
+    _set_logging()
+    ws = json.load(ws_spec)
+    model, data = cabinetry_model_utils.model_and_data(ws)
+
+    # optionally perform maximum likelihood fit to obtain post-fit model
+    fit_results = cabinetry_fit.fit(model, data) if postfit else None
+
+    model_prediction = cabinetry_model_utils.prediction(model, fit_results=fit_results)
+    cabinetry_tabulate.yields(
+        model_prediction,
+        data,
+        table_folder=tablefolder,
+        table_format=tablefmt,
+    )
+
+
+@click.command()
+@click.argument("ws_spec", type=click.File("r"))
+@click.option(
     "--split_by_sample",
     is_flag=True,
     help="split grids by sample (default: split by channel)",
@@ -371,4 +413,5 @@ cabinetry.add_command(scan)
 cabinetry.add_command(limit)
 cabinetry.add_command(significance)
 cabinetry.add_command(data_mc)
+cabinetry.add_command(yields)
 cabinetry.add_command(modifier_grid)

--- a/src/cabinetry/cli/__init__.py
+++ b/src/cabinetry/cli/__init__.py
@@ -350,8 +350,8 @@ def data_mc(
 def yields(
     ws_spec: io.TextIOWrapper,
     postfit: bool,
-    tablefmt: str,
     tablefolder: str,
+    tablefmt: str,
 ) -> None:
     """Creates yield tables of fit model and observed data.
 

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -576,10 +576,7 @@ def test_yields(mock_utils, mock_fit, mock_pred, mock_tab, tmp_path):
     assert mock_tab.call_args_list == [
         (
             ("mock_model_pred", "data"),
-            {
-                "table_folder": "tables",
-                "table_format": "simple",
-            },
+            {"table_folder": "tables", "table_format": "simple"},
         )
     ]
 
@@ -598,10 +595,7 @@ def test_yields(mock_utils, mock_fit, mock_pred, mock_tab, tmp_path):
     assert mock_pred.call_args == (("model",), {"fit_results": fit_results})
     assert mock_tab.call_args == (
         ("mock_model_pred", "data"),
-        {
-            "table_folder": "folder",
-            "table_format": "html",
-        },
+        {"table_folder": "folder", "table_format": "html"},
     )
 
 

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -541,6 +541,70 @@ def test_data_mc(
     )
 
 
+@mock.patch("cabinetry.tabulate.yields", autospec=True)
+@mock.patch(
+    "cabinetry.model_utils.prediction", return_value="mock_model_pred", autospec=True
+)
+@mock.patch(
+    "cabinetry.fit.fit",
+    return_value=fit.FitResults(
+        np.asarray([1.0]), np.asarray([0.1]), ["label"], np.asarray([[1.0]]), 1.0
+    ),
+    autospec=True,
+)
+@mock.patch(
+    "cabinetry.model_utils.model_and_data",
+    return_value=("model", "data"),
+    autospec=True,
+)
+def test_yields(mock_utils, mock_fit, mock_pred, mock_tab, tmp_path):
+    workspace = {"workspace": "mock"}
+    workspace_path = str(tmp_path / "workspace.json")
+
+    # need to save workspace to file since click looks for it
+    with open(workspace_path, "w") as f:
+        f.write('{"workspace": "mock"}')
+
+    runner = CliRunner()
+
+    # default
+    result = runner.invoke(cli.yields, [workspace_path])
+    assert result.exit_code == 0
+    assert mock_utils.call_args_list == [((workspace,), {})]
+    assert mock_fit.call_count == 0
+    assert mock_pred.call_args_list == [(("model",), {"fit_results": None})]
+    assert mock_tab.call_args_list == [
+        (
+            ("mock_model_pred", "data"),
+            {
+                "table_folder": "tables",
+                "table_format": "simple",
+            },
+        )
+    ]
+
+    # with post-fit, custom table folder and format
+    fit_results = fit.FitResults(
+        np.asarray([1.0]), np.asarray([0.1]), ["label"], np.asarray([[1.0]]), 1.0
+    )
+
+    result = runner.invoke(
+        cli.yields,
+        [workspace_path, "--postfit", "--tablefolder", "folder", "--tablefmt", "html"],
+    )
+    assert result.exit_code == 0
+    assert mock_utils.call_args == ((workspace,), {})
+    assert mock_fit.call_args_list == [(("model", "data"), {})]
+    assert mock_pred.call_args == (("model",), {"fit_results": fit_results})
+    assert mock_tab.call_args == (
+        ("mock_model_pred", "data"),
+        {
+            "table_folder": "folder",
+            "table_format": "html",
+        },
+    )
+
+
 @mock.patch("cabinetry.visualize.modifier_grid", autospec=True)
 @mock.patch(
     "cabinetry.model_utils.model_and_data",


### PR DESCRIPTION
Adds yield tables to the CLI. Output folder and format are configurable.

```
* added yield tables to the command line interface
* updated pre-commit
```