### PR TITLE
fix: parameter uncertainties for partially fixed parameters

### DIFF
--- a/src/cabinetry/model_utils.py
+++ b/src/cabinetry/model_utils.py
@@ -179,15 +179,19 @@ def prefit_uncertainties(model: pyhf.pdf.Model) -> np.ndarray:
     """
     pre_fit_unc = []  # pre-fit uncertainties for parameters
     for parameter in model.config.par_order:
-        # obtain pre-fit uncertainty for constrained, non-fixed parameters
-        if (
-            model.config.param_set(parameter).constrained
-            and not model.config.param_set(parameter).suggested_fixed_as_bool
-        ):
-            pre_fit_unc += model.config.param_set(parameter).width()
+        # obtain pre-fit uncertainty for constrained parameters (if fixed, set to 0.0)
+        if model.config.param_set(parameter).constrained:
+            widths = [
+                width if not fixed else 0.0
+                for width, fixed in zip(
+                    model.config.param_set(parameter).width(),
+                    model.config.param_set(parameter).suggested_fixed,
+                )
+            ]
+            pre_fit_unc += widths
         else:
             if model.config.param_set(parameter).n_parameters == 1:
-                # unconstrained normfactor or fixed parameter, uncertainty is 0
+                # unconstrained normfactor, uncertainty is 0
                 pre_fit_unc.append(0.0)
             else:
                 # shapefactor

--- a/src/cabinetry/model_utils.py
+++ b/src/cabinetry/model_utils.py
@@ -179,8 +179,8 @@ def prefit_uncertainties(model: pyhf.pdf.Model) -> np.ndarray:
     """
     pre_fit_unc = []  # pre-fit uncertainties for parameters
     for parameter in model.config.par_order:
-        # obtain pre-fit uncertainty for constrained parameters (if fixed, set to 0.0)
         if model.config.param_set(parameter).constrained:
+            # pre-fit uncertainty for constrained parameters (if fixed, set to 0.0)
             widths = [
                 width if not fixed else 0.0
                 for width, fixed in zip(
@@ -190,12 +190,8 @@ def prefit_uncertainties(model: pyhf.pdf.Model) -> np.ndarray:
             ]
             pre_fit_unc += widths
         else:
-            if model.config.param_set(parameter).n_parameters == 1:
-                # unconstrained normfactor, uncertainty is 0
-                pre_fit_unc.append(0.0)
-            else:
-                # shapefactor
-                pre_fit_unc += [0.0] * model.config.param_set(parameter).n_parameters
+            # unconstrained: normfactor or shapefactor, uncertainty is 0
+            pre_fit_unc += [0.0] * model.config.param_set(parameter).n_parameters
     return np.asarray(pre_fit_unc)
 
 

--- a/src/cabinetry/model_utils.py
+++ b/src/cabinetry/model_utils.py
@@ -480,11 +480,9 @@ def unconstrained_parameter_count(model: pyhf.pdf.Model) -> int:
     """
     n_pars = 0
     for parname in model.config.par_order:
-        if (
-            not model.config.param_set(parname).constrained
-            and not model.config.param_set(parname).suggested_fixed_as_bool
-        ):
-            n_pars += model.config.param_set(parname).n_parameters
+        if not model.config.param_set(parname).constrained:
+            # only consider non-constant parameters
+            n_pars += model.config.param_set(parname).suggested_fixed.count(False)
     return n_pars
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -379,6 +379,43 @@ def example_spec_modifiers():
     return spec
 
 
+@pytest.fixture
+def example_spec_zero_staterror():
+    spec = {
+        "channels": [
+            {
+                "name": "SR",
+                "samples": [
+                    {
+                        "data": [5.0, 0.0],
+                        "modifiers": [
+                            {"data": None, "name": "mu", "type": "normfactor"},
+                            {
+                                "data": [1.0, 0.0],
+                                "name": "staterror_SR",
+                                "type": "staterror",
+                            },
+                        ],
+                        "name": "Signal",
+                    }
+                ],
+            }
+        ],
+        "measurements": [
+            {
+                "config": {
+                    "parameters": [],
+                    "poi": "mu",
+                },
+                "name": "zero staterror",
+            }
+        ],
+        "observations": [{"data": [5, 0], "name": "SR"}],
+        "version": "1.0.0",
+    }
+    return spec
+
+
 # code below allows marking tests as slow and adds --runslow to run them
 # implemented following https://docs.pytest.org/en/6.2.x/example/simple.html
 def pytest_addoption(parser):

--- a/tests/test_model_utils.py
+++ b/tests/test_model_utils.py
@@ -147,7 +147,10 @@ def test_asimov_parameters(example_spec, example_spec_shapefactor, example_spec_
 
 
 def test_prefit_uncertainties(
-    example_spec, example_spec_multibin, example_spec_shapefactor
+    example_spec,
+    example_spec_multibin,
+    example_spec_shapefactor,
+    example_spec_zero_staterror,
 ):
     model = pyhf.Workspace(example_spec).model()
     unc = model_utils.prefit_uncertainties(model)
@@ -160,6 +163,10 @@ def test_prefit_uncertainties(
     model = pyhf.Workspace(example_spec_shapefactor).model()
     unc = model_utils.prefit_uncertainties(model)
     assert np.allclose(unc, [0.0, 0.0, 0.0])
+
+    model = pyhf.Workspace(example_spec_zero_staterror).model()
+    unc = model_utils.prefit_uncertainties(model)
+    assert np.allclose(unc, [0.0, 0.2, 0.0])  # partially fixed staterror
 
 
 def test__hashable_model_key(example_spec):


### PR DESCRIPTION
In the presence of partially fixed parameters (currently this only happens for `staterror` modifiers that are constant in some bins due to zero yield + uncertainty, see https://github.com/scikit-hep/pyhf/issues/1944) the previously used `model.config.suggested_fixed_as_bool` will not work. Instead, `model.config.suggested_fixed` works fine to handle these mixed cases.

The same update is made for the counting of the number of unconstrained parameters. This should in principle correctly handle partially fixed `shapefactor` modifiers, however this currently cannot be achieved in `pyhf` (see https://github.com/scikit-hep/pyhf/issues/2053). This means the behavior currently cannot be tested.

resolves #390

```
* fix pre-fit parameter uncertainty evaluation for partially fixed parameters
* support unconstrained degree of freedom counting for partially fixed parameters
```