### PR TITLE
chore: updating version to 0.5.2

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = cabinetry
-version = 0.5.1
+version = 0.5.2
 author = Alexander Held
 description = design and steer profile likelihood fits
 long_description = file: README.md

--- a/src/cabinetry/__init__.py
+++ b/src/cabinetry/__init__.py
@@ -35,7 +35,7 @@ def __dir__() -> List[str]:
     return __all__
 
 
-__version__ = "0.5.1"
+__version__ = "0.5.2"
 
 
 def set_logging() -> None:


### PR DESCRIPTION
Updating to version `0.5.2`. This fixes the handling of parameter uncertainties for partially fixed parameters and the handling of negative model predictions in plots, adds yield tables to the command line interface, and improves editor autocompletion.

```
* updating version to 0.5.2
```