### PR TITLE
feat: support custom colors for data/MC plots

### DIFF
--- a/src/cabinetry/visualize/__init__.py
+++ b/src/cabinetry/visualize/__init__.py
@@ -76,7 +76,7 @@ def data_mc_from_histograms(
         channels (Optional[Union[str, List[str]]], optional): name of channel to show,
             or list of names to include, defaults to None (uses all channels)
         colors (Optional[Dict[str, str]], optional): map of sample names and colors to
-            use in plot, defaults to None (use default colors)
+            use in plot, defaults to None (uses default colors)
         close_figure (bool, optional): whether to close each figure, defaults to False
             (enable when producing many figures to avoid memory issues, prevents
             automatic rendering in notebooks)
@@ -191,7 +191,7 @@ def data_mc(
         channels (Optional[Union[str, List[str]]], optional): name of channel to show,
             or list of names to include, defaults to None (uses all channels)
         colors (Optional[Dict[str, str]], optional): map of sample names and colors to
-            use in plot, defaults to None (use default colors)
+            use in plot, defaults to None (uses default colors)
         close_figure (bool, optional): whether to close each figure, defaults to False
             (enable when producing many figures to avoid memory issues, prevents
             automatic rendering in notebooks)

--- a/src/cabinetry/visualize/__init__.py
+++ b/src/cabinetry/visualize/__init__.py
@@ -104,9 +104,8 @@ def data_mc_from_histograms(
             )
 
     # create a list of channels to process
-    if channels is not None:
-        if isinstance(channels, str):
-            channels = [channels]
+    if channels is not None and isinstance(channels, str):
+        channels = [channels]
 
     for region in config["Regions"]:
         if channels is not None and region["Name"] not in channels:

--- a/src/cabinetry/visualize/__init__.py
+++ b/src/cabinetry/visualize/__init__.py
@@ -134,6 +134,7 @@ def data_mc(
     log_scale: Optional[bool] = None,
     log_scale_x: bool = False,
     channels: Optional[Union[str, List[str]]] = None,
+    colors: Optional[Dict[str, str]] = None,
     close_figure: bool = False,
     save_figure: bool = True,
 ) -> Optional[List[Dict[str, Any]]]:
@@ -159,6 +160,8 @@ def data_mc(
             defaults to False
         channels (Optional[Union[str, List[str]]], optional): name of channel to show,
             or list of names to include, defaults to None (uses all channels)
+        colors (Optional[Dict[str, str]], optional): map of sample names and colors to
+            use in plot, defaults to None (use default colors)
         close_figure (bool, optional): whether to close each figure, defaults to False
             (enable when producing many figures to avoid memory issues, prevents
             automatic rendering in notebooks)
@@ -171,6 +174,14 @@ def data_mc(
     """
     # strip off auxdata (if needed) and obtain data indexed by channel (and bin)
     data_yields = model_utils._data_per_channel(model_prediction.model, data)
+
+    # if custom colors are provided, ensure that they cover all samples
+    if colors is not None:
+        c_missing = set(model_prediction.model.config.samples).difference(colors.keys())
+        if c_missing:
+            raise ValueError(
+                f"colors need to be provided for all samples, missing for {c_missing}"
+            )
 
     # channels to include in table, with optional filtering applied
     filtered_channels = model_utils._filter_channels(model_prediction.model, channels)
@@ -241,6 +252,7 @@ def data_mc(
             log_scale=log_scale,
             log_scale_x=log_scale_x,
             label=label,
+            colors=colors,
             close_figure=close_figure,
         )
         figure_dict_list.append({"figure": fig, "region": channel_name})

--- a/src/cabinetry/visualize/__init__.py
+++ b/src/cabinetry/visualize/__init__.py
@@ -107,11 +107,9 @@ def data_mc_from_histograms(
     if channels is not None:
         if isinstance(channels, str):
             channels = [channels]
-    else:
-        channels = [region["Name"] for region in config["Regions"]]
 
     for region in config["Regions"]:
-        if region["Name"] not in channels:
+        if channels is not None and region["Name"] not in channels:
             continue  # skip region
         histogram_dict_list = []
         model_stdevs = []

--- a/src/cabinetry/visualize/plot_model.py
+++ b/src/cabinetry/visualize/plot_model.py
@@ -50,7 +50,7 @@ def data_mc(
             defaults to False
         label (str, optional): label written on the figure, defaults to ""
         colors (Optional[Dict[str, str]], optional): map of sample names and colors to
-            use in plot, defaults to None (use default colors)
+            use in plot, defaults to None (uses default colors)
         close_figure (bool, optional): whether to close each figure immediately after
             saving it, defaults to False (enable when producing many figures to avoid
             memory issues, prevents rendering in notebooks)

--- a/src/cabinetry/visualize/plot_model.py
+++ b/src/cabinetry/visualize/plot_model.py
@@ -30,6 +30,7 @@ def data_mc(
     log_scale: Optional[bool] = None,
     log_scale_x: bool = False,
     label: str = "",
+    colors: Optional[Dict[str, str]] = None,
     close_figure: bool = False,
 ) -> mpl.figure.Figure:
     """Draws a data/MC histogram with uncertainty bands and ratio panel.
@@ -48,6 +49,8 @@ def data_mc(
         log_scale_x (bool, optional): whether to use logarithmic horizontal axis,
             defaults to False
         label (str, optional): label written on the figure, defaults to ""
+        colors (Optional[Dict[str, str]], optional): map of sample names and colors to
+            use in plot, defaults to None (use default colors)
         close_figure (bool, optional): whether to close each figure immediately after
             saving it, defaults to False (enable when producing many figures to avoid
             memory issues, prevents rendering in notebooks)
@@ -102,9 +105,13 @@ def data_mc(
         else bin_centers
     )
     mc_containers = []
-    for mc_sample_yield in mc_histograms_yields:
+    for mc_sample_yield, sample_label in zip(mc_histograms_yields, mc_labels):
         mc_container = ax1.bar(
-            bin_centers, mc_sample_yield, width=bin_width, bottom=total_yield
+            bin_centers,
+            mc_sample_yield,
+            width=bin_width,
+            bottom=total_yield,
+            color=colors[sample_label] if colors else None,
         )
         mc_containers.append(mc_container)
 

--- a/tests/visualize/test_visualize.py
+++ b/tests/visualize/test_visualize.py
@@ -105,6 +105,7 @@ def test_data_mc_from_histograms(mock_load, mock_draw, mock_stdev):
                 "log_scale": None,
                 "log_scale_x": False,
                 "label": "reg_1\npre-fit",
+                "colors": None,
                 "close_figure": False,
             },
         )
@@ -124,6 +125,7 @@ def test_data_mc_from_histograms(mock_load, mock_draw, mock_stdev):
         "log_scale": True,
         "log_scale_x": True,
         "label": "reg_1\npre-fit",
+        "colors": None,
         "close_figure": True,
     }
 
@@ -191,6 +193,7 @@ def test_data_mc(mock_data, mock_filter, mock_dict, mock_bins, mock_draw, exampl
         "log_scale": None,
         "log_scale_x": False,
         "label": "Signal Region\npre-fit",
+        "colors": None,
         "close_figure": False,
     }
 
@@ -224,6 +227,7 @@ def test_data_mc(mock_data, mock_filter, mock_dict, mock_bins, mock_draw, exampl
         "log_scale": False,
         "log_scale_x": False,
         "label": "Signal Region\npost-fit",
+        "colors": None,
         "close_figure": True,
     }
 

--- a/tests/visualize/test_visualize.py
+++ b/tests/visualize/test_visualize.py
@@ -111,12 +111,15 @@ def test_data_mc_from_histograms(mock_load, mock_draw, mock_stdev):
         )
     ]
 
-    # custom log scale settings, close figure, do not save figure
+    # custom log scale settings, close figure, do not save figure, channel specified,
+    # custom colors
     _ = visualize.data_mc_from_histograms(
         config,
         figure_folder=figure_folder,
         log_scale=True,
         log_scale_x=True,
+        channels=["reg_1"],
+        colors={"sample_1": "red"},
         close_figure=True,
         save_figure=False,
     )
@@ -125,9 +128,19 @@ def test_data_mc_from_histograms(mock_load, mock_draw, mock_stdev):
         "log_scale": True,
         "log_scale_x": True,
         "label": "reg_1\npre-fit",
-        "colors": None,
+        "colors": {"sample_1": "red"},
         "close_figure": True,
     }
+
+    # no matching channels
+    assert visualize.data_mc_from_histograms(config, channels="abc") == []
+
+    # incomplete color specification
+    with pytest.raises(
+        ValueError,
+        match="colors need to be provided for all samples, missing for {'sample_1'}",
+    ):
+        _ = visualize.data_mc_from_histograms(config, colors={})
 
 
 @mock.patch(
@@ -198,8 +211,8 @@ def test_data_mc(mock_data, mock_filter, mock_dict, mock_bins, mock_draw, exampl
     }
 
     # post-fit plot (different label in model prediction), custom scale, close figure,
-    # do not save figure, histogram input mode: no binning or variable specified (via
-    # side effect)
+    # do not save figure, custom colors, histogram input mode: no binning or variable
+    # specified (via side effect)
     model_pred = model_utils.ModelPrediction(
         model, [[[11.0]]], [[[0.2], [0.2]]], [[0.2, 0.2]], "post-fit"
     )
@@ -209,6 +222,7 @@ def test_data_mc(mock_data, mock_filter, mock_dict, mock_bins, mock_draw, exampl
         config=config,
         figure_folder=figure_folder,
         log_scale=False,
+        colors={"Signal": "red"},
         close_figure=True,
         save_figure=False,
     )
@@ -227,7 +241,7 @@ def test_data_mc(mock_data, mock_filter, mock_dict, mock_bins, mock_draw, exampl
         "log_scale": False,
         "log_scale_x": False,
         "label": "Signal Region\npost-fit",
-        "colors": None,
+        "colors": {"Signal": "red"},
         "close_figure": True,
     }
 
@@ -242,6 +256,13 @@ def test_data_mc(mock_data, mock_filter, mock_dict, mock_bins, mock_draw, exampl
     assert visualize.data_mc(model_pred, data, channels="abc") is None
     assert mock_filter.call_args == ((model, "abc"), {})
     assert mock_draw.call_count == 3  # no new call
+
+    # incomplete color specification
+    with pytest.raises(
+        ValueError,
+        match="colors need to be provided for all samples, missing for {'Signal'}",
+    ):
+        _ = visualize.data_mc(model_pred, data, colors={})
 
 
 @mock.patch(

--- a/tests/visualize/test_visualize_plot_model.py
+++ b/tests/visualize/test_visualize_plot_model.py
@@ -1,6 +1,7 @@
 import copy
 from unittest import mock
 
+import matplotlib as mpl
 import matplotlib.pyplot as plt
 from matplotlib.testing.compare import compare_images
 import numpy as np
@@ -103,19 +104,30 @@ def test_data_mc(tmp_path, caplog):
 
     # do not save figure, but close it
     # one bin with zero model prediction
+    # custom histogram colors
     histo_dict_list[0]["yields"] = np.asarray([0, 14])
     histo_dict_list[1]["yields"] = np.asarray([0, 5])
     caplog.clear()
     with mock.patch("cabinetry.visualize.utils._save_and_close") as mock_close_safe:
         with pytest.warns() as warn_record:
-            fig = fig = plot_model.data_mc(
+            fig = plot_model.data_mc(
                 histo_dict_list,
                 total_model_unc_log,
                 bin_edges_log,
                 label="",
+                colors={"Background": "blue", "Signal": "red"},
                 close_figure=True,
             )
             assert mock_close_safe.call_args_list == [((fig, None, True), {})]
+            # custom colors propagated to histogram
+            assert (
+                fig.axes[0].containers[0].patches[0].get_facecolor()
+                == mpl.colors.to_rgba_array("blue")
+            ).all()
+            assert (
+                fig.axes[0].containers[1].patches[0].get_facecolor()
+                == mpl.colors.to_rgba_array("red")
+            ).all()
 
     assert "predicted yield is zero in 1 bin(s), excluded from ratio plot" in [
         rec.message for rec in caplog.records


### PR DESCRIPTION
Adding a new `colors` argument to `visualize.data_mc` and `visualize.data_mc_from_histograms` (as well as `visualize.plot_model.data_mc`) that allows specifying color names per sample: `colors={"signal": "red", "background": "blue"}`. Colors need to be provided for all samples, otherwise an exception is raised. If colors are invalid, an exception will later on be raised via `matplotlib`. The default behavior is unchanged, falling back to the `seaborn-colorblind` colors.

`visualize.data_mc_from_histograms` was still missing the `channels` kwarg, this is now also included. 

```
* support custom histogram colors for visualize.data_mc via new colors keyword argument
* support custom histogram colors in visualize.plot_model.data_mc
* extend color and channel filtering functionality to visualize.data_mc_from_histograms
```

resolves #381 (rest of that issue migrated to #265)