### PR TITLE
build: drop support for Python 3.7

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.8', '3.9', '3.10', '3.11']
 
     steps:
     - uses: actions/checkout@v3

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@ repos:
     hooks:
     -   id: black
 -   repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.1.1
+    rev: v1.2.0
     hooks:
     -   id: mypy
         name: mypy with Python 3.8
@@ -22,7 +22,7 @@ repos:
     -   id: flake8
         additional_dependencies: [flake8-bugbear, flake8-import-order, flake8-print]
 -   repo: https://github.com/asottile/pyupgrade
-    rev: v3.3.1
+    rev: v3.3.2
     hooks:
     -   id: pyupgrade
         args: ["--py38-plus"]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,7 +25,7 @@ repos:
     rev: v3.3.1
     hooks:
     -   id: pyupgrade
-        args: ["--py37-plus"]
+        args: ["--py38-plus"]
 -   repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.4.0
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@ repos:
     hooks:
     -   id: black
 -   repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.2.0
+    rev: v1.3.0
     hooks:
     -   id: mypy
         name: mypy with Python 3.8
@@ -22,7 +22,7 @@ repos:
     -   id: flake8
         additional_dependencies: [flake8-bugbear, flake8-import-order, flake8-print]
 -   repo: https://github.com/asottile/pyupgrade
-    rev: v3.3.2
+    rev: v3.4.0
     hooks:
     -   id: pyupgrade
         args: ["--py38-plus"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["setuptools>=42"]
 build-backend = "setuptools.build_meta"
 
 [tool.black]
-target-version = ['py37', 'py38']
+target-version = ['py38']
 include = '\.pyi?$'
 exclude = '''
 /(

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,7 +28,6 @@ install_requires =
     awkward>=1.8  # _v2 API in submodule
     tabulate>=0.8.1  # multiline text
     matplotlib>=3.5.0  # layout kwarg for subplots
-    typing_extensions;python_version<"3.8"  # for Literal type
     # below are direct dependencies of cabinetry, which are also included via pyhf[iminuit]
     numpy
     pyyaml

--- a/setup.cfg
+++ b/setup.cfg
@@ -10,7 +10,6 @@ license_files = LICENSE
 url = https://github.com/scikit-hep/cabinetry
 classifiers =
     Development Status :: 3 - Alpha
-    Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
@@ -22,7 +21,7 @@ classifiers =
 [options]
 packages = find:
 package_dir = =src
-python_requires = >=3.7
+python_requires = >=3.8
 install_requires =
     pyhf[minuit]~=0.7.0  # model.config.suggested_fixed / .par_names API changes, set_poi(None)
     boost_histogram>=1.0.0  # subclassing with family, 1.02 for stdev scaling fix (currently not needed)

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ extras_require["test"] = sorted(
             "mypy",
             "types-tabulate",
             "types-PyYAML",
-            "typeguard~=2.13",  # typing.NamedTuple in Python 3.7, cabinetry#391
+            "typeguard~=2.13",  # cabinetry#391
             "black",
         ]
     )

--- a/src/cabinetry/_typing.py
+++ b/src/cabinetry/_typing.py
@@ -1,8 +1,0 @@
-"""Utility to import the Literal type."""
-
-import sys
-
-if sys.version_info < (3, 8):
-    from typing_extensions import Literal  # noqa: F401, # pragma: no cover
-else:
-    from typing import Literal  # noqa: F401, # pragma: no cover

--- a/src/cabinetry/configuration.py
+++ b/src/cabinetry/configuration.py
@@ -4,12 +4,10 @@ import json
 import logging
 import pathlib
 import pkgutil
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, List, Literal, Optional, Union
 
 import jsonschema
 import yaml
-
-from cabinetry._typing import Literal
 
 
 log = logging.getLogger(__name__)

--- a/src/cabinetry/fit/__init__.py
+++ b/src/cabinetry/fit/__init__.py
@@ -1,7 +1,7 @@
 """High-level entry point for statistical inference."""
 
 import logging
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Any, Dict, List, Literal, Optional, Tuple, Union
 
 import iminuit
 import numpy as np
@@ -10,7 +10,6 @@ import scipy.optimize
 import scipy.stats
 
 from cabinetry import model_utils
-from cabinetry._typing import Literal
 from cabinetry.fit.results_containers import (
     FitResults,
     LimitResults,

--- a/src/cabinetry/histo.py
+++ b/src/cabinetry/histo.py
@@ -3,13 +3,12 @@
 import logging
 import os
 import pathlib
-from typing import Any, Dict, List, Optional, Type, TypeVar, Union
+from typing import Any, Dict, List, Literal, Optional, Type, TypeVar, Union
 
 import boost_histogram as bh
 import numpy as np
 
 import cabinetry
-from cabinetry._typing import Literal
 
 
 log = logging.getLogger(__name__)

--- a/src/cabinetry/route.py
+++ b/src/cabinetry/route.py
@@ -2,12 +2,11 @@
 
 import fnmatch
 import logging
-from typing import Any, Callable, Dict, List, Optional
+from typing import Any, Callable, Dict, List, Literal, Optional
 
 import boost_histogram as bh
 
 from cabinetry import configuration
-from cabinetry._typing import Literal
 
 
 log = logging.getLogger(__name__)

--- a/src/cabinetry/templates/builder.py
+++ b/src/cabinetry/templates/builder.py
@@ -3,7 +3,7 @@
 import functools
 import logging
 import pathlib
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Literal, Optional
 
 import boost_histogram as bh
 import numpy as np
@@ -11,7 +11,6 @@ import numpy as np
 from cabinetry import configuration
 from cabinetry import histo
 from cabinetry import route
-from cabinetry._typing import Literal
 from cabinetry.templates import utils
 
 

--- a/src/cabinetry/templates/collector.py
+++ b/src/cabinetry/templates/collector.py
@@ -2,11 +2,10 @@
 
 import logging
 import pathlib
-from typing import Any, cast, Dict, Optional
+from typing import Any, cast, Dict, Literal, Optional
 
 from cabinetry import histo
 from cabinetry import route
-from cabinetry._typing import Literal
 from cabinetry.templates import utils
 
 

--- a/src/cabinetry/templates/postprocessor.py
+++ b/src/cabinetry/templates/postprocessor.py
@@ -3,7 +3,7 @@
 import copy
 import logging
 import pathlib
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Literal, Optional
 
 import numpy as np
 
@@ -11,7 +11,6 @@ from cabinetry import configuration
 from cabinetry import histo
 from cabinetry import route
 from cabinetry import smooth
-from cabinetry._typing import Literal
 
 
 log = logging.getLogger(__name__)

--- a/src/cabinetry/templates/utils.py
+++ b/src/cabinetry/templates/utils.py
@@ -1,10 +1,9 @@
 """Provides utilities for template histogram handling."""
 
 import pathlib
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, List, Literal, Optional, Union
 
 from cabinetry import histo
-from cabinetry._typing import Literal
 
 
 def _check_for_override(

--- a/src/cabinetry/visualize/plot_model.py
+++ b/src/cabinetry/visualize/plot_model.py
@@ -14,7 +14,7 @@ from cabinetry.visualize import utils
 
 log = logging.getLogger(__name__)
 
-# handling of matplotlib<3.6 (for Python 3.7)
+# handling of matplotlib<3.6
 if packaging.version.parse(mpl.__version__) < packaging.version.parse("3.6"):
     MPL_STYLE = "seaborn-colorblind"  # pragma: no cover
 else:

--- a/src/cabinetry/visualize/plot_result.py
+++ b/src/cabinetry/visualize/plot_result.py
@@ -15,7 +15,7 @@ from cabinetry.visualize import utils
 
 log = logging.getLogger(__name__)
 
-# handling of matplotlib<3.6 (for Python 3.7)
+# handling of matplotlib<3.6
 if packaging.version.parse(mpl.__version__) < packaging.version.parse("3.6"):
     MPL_GEQ_36 = False  # pragma: no cover
     MPL_STYLE = "seaborn-colorblind"  # pragma: no cover


### PR DESCRIPTION
Following `pyhf` (https://github.com/scikit-hep/pyhf/pull/2044), this drops support for Python 3.7. The NEP 29 schedule puts Python 3.8+ at Dec 26, 2021, which already was one and a half years ago. The last `cabinetry` version to support Python 3.7 will presumably remain `0.5.2` (alongside with `pyhf` version `0.7.1`).

This allows dropping the `_typing` submodule that was used for the `Literal` type via `typing_extensions` with Python 3.7.

Ran `pyupgrade --py38-plus`, which did not seem to introduce any other changes.

The previous drop of Python 3.6 happened in #194. These changes also mean that `pre-commit` `mypy` is again testing against the lowest supported version (see #371).

```
* future versions of cabinetry require at least Python 3.8
* drop support and testing of Python 3.7
* updated pre-commit
```