### PR TITLE
fix: typing for file opened for writing with click

### DIFF
--- a/src/cabinetry/cli/__init__.py
+++ b/src/cabinetry/cli/__init__.py
@@ -75,7 +75,7 @@ def postprocess(config: io.TextIOWrapper) -> None:
 @click.command()
 @click.argument("config", type=click.File("r"))
 @click.argument("ws_spec", type=click.File("w"))
-def workspace(config: io.TextIOWrapper, ws_spec: io.TextIOWrapper) -> None:
+def workspace(config: io.TextIOWrapper, ws_spec: click.utils.LazyFile) -> None:
     """Produces a ``pyhf`` workspace.
 
     CONFIG: path to cabinetry configuration file


### PR DESCRIPTION
`click` opens files for writing lazily, meaning that a file opened for writing is not immediately an `io.TextIOWrapper` but a `click.utils.LazyFile` for the purpose of typing: https://click.palletsprojects.com/en/8.1.x/api/#click.File. This was flagged by `typeguard` version `4.0.0rc4` (which will be adopted after full release via #391).

```
* fix typing for file opened for writing with click in command line interface
```