### PR TITLE
fix: adopt typeguard version 4.0

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -51,9 +51,6 @@ console_scripts =
 
 [tool:pytest]
 addopts = --cov=cabinetry --cov-report html --cov-report term-missing --cov-branch -rsx --typeguard-packages=cabinetry
-filterwarnings =
-    ignore:no type annotations present:UserWarning:typeguard:
-    ignore:no code associated:UserWarning:typeguard:
 
 [flake8]
 max-complexity = 18

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ extras_require["test"] = sorted(
             "mypy",
             "types-tabulate",
             "types-PyYAML",
-            "typeguard~=2.13",  # cabinetry#391
+            "typeguard>=4.0.0",  # cabinetry#391
             "black",
         ]
     )

--- a/src/cabinetry/smooth.py
+++ b/src/cabinetry/smooth.py
@@ -10,8 +10,7 @@ import numpy as np
 log = logging.getLogger(__name__)
 
 
-# typeguard raises errors in tests when using List[float] instead of list
-T = TypeVar("T", list, np.ndarray)
+T = TypeVar("T", List[float], np.ndarray)
 
 
 def _medians_353(zz: Union[List[float], np.ndarray], nbins: int) -> None:


### PR DESCRIPTION
Relax the requirement of `typeguard<3` introduced in #392 and adopt version 4.0.

resolves #391

```
* require typeguard>=4.0
* remove typing workarounds that are no longer required
```