### PR TITLE
feat: denote constant parameters when printing fit results

### DIFF
--- a/src/cabinetry/fit/__init__.py
+++ b/src/cabinetry/fit/__init__.py
@@ -25,15 +25,19 @@ log = logging.getLogger(__name__)
 def print_results(fit_results: FitResults) -> None:
     """Prints the best-fit parameter results and associated uncertainties.
 
+    Parameters with zero uncertainty (those held fixed in the fit) are in addition
+    denoted with "(constant)".
+
     Args:
         fit_results (FitResults): results of fit to be printed
     """
     max_label_length = max(len(label) for label in fit_results.labels)
     log.info("fit results (with symmetric uncertainties):")
     for i, label in enumerate(fit_results.labels):
+        const_label = "  (constant)" if fit_results.uncertainty[i] == 0.0 else ""
         log.info(
             f"{label:<{max_label_length}} = {fit_results.bestfit[i]: .4f} +/- "
-            f"{fit_results.uncertainty[i]:.4f}"
+            f"{fit_results.uncertainty[i]:.4f}{const_label}"
         )
 
 

--- a/tests/fit/test_fit.py
+++ b/tests/fit/test_fit.py
@@ -24,7 +24,7 @@ def test_print_results(caplog):
     assert "param_B =  2.0000 +/- 0.3000" in [rec.message for rec in caplog.records]
     caplog.clear()
 
-    # constant parameters
+    # constant parameter
     uncertainty = np.asarray([0.1, 0.0])
     fit_results = fit.FitResults(bestfit, uncertainty, labels, np.empty(0), 0.0)
     fit.print_results(fit_results)

--- a/tests/fit/test_fit.py
+++ b/tests/fit/test_fit.py
@@ -24,6 +24,15 @@ def test_print_results(caplog):
     assert "param_B =  2.0000 +/- 0.3000" in [rec.message for rec in caplog.records]
     caplog.clear()
 
+    # constant parameters
+    uncertainty = np.asarray([0.1, 0.0])
+    fit_results = fit.FitResults(bestfit, uncertainty, labels, np.empty(0), 0.0)
+    fit.print_results(fit_results)
+    assert "param_B =  2.0000 +/- 0.0000  (constant)" in [
+        rec.message for rec in caplog.records
+    ]
+    caplog.clear()
+
 
 # skip a "RuntimeWarning: numpy.ufunc size changed" warning
 # due to different numpy versions used in dependencies


### PR DESCRIPTION
Add a `(constant)` flag when printing parameters that were held fixed in fits, which subsequently have zero uncertainty. This allows for more easily distinguishing them from the rest.

```
* denote constant parameters as such when printing fit results
```