### PR TITLE
docs: fix return value type in docstring

### DIFF
--- a/src/cabinetry/visualize/__init__.py
+++ b/src/cabinetry/visualize/__init__.py
@@ -44,7 +44,7 @@ def _total_yield_uncertainty(stdev_list: List[np.ndarray]) -> np.ndarray:
         stdev_list (List[np.ndarray]): list of absolute stat. uncertainty per sample
 
     Returns:
-        np.array: absolute stat. uncertainty of stack of samples
+        np.ndarray: absolute stat. uncertainty of stack of samples
     """
     tot_unc = np.sqrt(np.sum(np.power(np.asarray(stdev_list), 2), axis=0))
     return tot_unc


### PR DESCRIPTION
Small fix for consistency: `np.ndarray` is the correct return value type of `visualize._total_yield_uncertainty` instead of `np.array`. The type hint was already correct.

```
* fix return value type in docstring of visualize._total_yield_uncertainty
```