### PR TITLE
fix: raise minimum Python version for type checking to 3.9

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,10 +7,11 @@ repos:
     rev: v1.3.0
     hooks:
     -   id: mypy
-        name: mypy with Python 3.8
+        name: mypy with Python 3.9
         files: src/cabinetry
         additional_dependencies: ["numpy>=1.22", "boost-histogram>=1.0.1", "click>=8", "types-tabulate", "types-PyYAML"]
-        args: ["--python-version=3.8"]
+        # numpy 1.25 is no longer compatible with Python 3.8, so use Python >=3.9 for type checking
+        args: ["--python-version=3.9"]
     -   id: mypy
         name: mypy with Python 3.11
         files: src/cabinetry

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,8 @@ warn_unreachable = true
 warn_unused_ignores = true
 strict_equality = true
 no_implicit_optional = true
-python_version = "3.8"
+# numpy 1.25 is no longer compatible with Python 3.8, so use Python >=3.9 for type checking
+python_version = "3.9"
 
 [[tool.mypy.overrides]]
 module = [


### PR DESCRIPTION
The latest version of `numpy`, 1.25.0, dropped compatibility with Python 3.8. When using `mypy` on `cabinetry` with Python 3.8 and the settings from the `pyproject.toml`, this results in errors getting raised in `cabinetry`. An example is the following:
```python
import numpy as np

a = np.asarray([1, 2, 3])
b = a.copy()
c = a.copy().astype(float)
d: np.ndarray = a.copy().astype(float)
```
resulting in
```python
test.py:5: error: Need type annotation for "c"  [var-annotated]
    c = a.copy().astype(float)
        ^~~~~~~~~~~~~~~~~~~~~~
Found 1 error in 1 file (checked 1 source file)
```

This is addressed here by raising the minimum Python version for the type checks being performed to Python 3.9.

```
* raise minimum Python version for mypy to Python 3.9 for compatibility with numpy 1.25.0
```