### PR TITLE
support rebinning in histogram postprocessing

### DIFF
--- a/config_example.yml
+++ b/config_example.yml
@@ -9,6 +9,10 @@ Regions:
     Variable: "jet_pt"
     Filter: "lep_charge > 0"
     Binning: [200, 300, 400, 500, 600]
+    Rebin:
+      LowerIndex: -1
+      UpperIndex: 8
+      Steps: -5
 
 Samples:
   - Name: "Data"

--- a/example.py
+++ b/example.py
@@ -17,10 +17,12 @@ if __name__ == "__main__":
     cabinetry.configuration.print_overview(config)
 
     # create template histograms
-    cabinetry.templates.build(config, method="uproot")
+    # cabinetry.templates.build(config, method="uproot")
 
     # perform histogram post-processing
     cabinetry.templates.postprocess(config)
+
+    raise SystemExit
 
     # visualize systematic templates
     cabinetry.visualize.templates(config)

--- a/src/cabinetry/schemas/config.json
+++ b/src/cabinetry/schemas/config.json
@@ -145,6 +145,10 @@
                     },
                     "uniqueItems": true
                 },
+                "Rebin": {
+                    "description": "rebinning to apply",
+                    "$ref": "#/definitions/rebin_setting"
+                },
                 "Filter": {
                     "description": "selection criteria to apply",
                     "type": "string"
@@ -397,6 +401,27 @@
                     "uniqueItems": true
                 }
             ]
+        },
+        "rebin_setting": {
+            "title": "Rebin setting",
+            "$$target": "#/definitions/rebin_setting",
+            "description": "rebin settings for template histograms",
+            "type": "object",
+            "properties": {
+                "LowerIndex": {
+                    "description": "zero-based lower index for histogram",
+                    "type": "integer"
+                },
+                "UpperIndex": {
+                    "description": "zero-based upper index for histogram",
+                    "type": "integer"
+                },
+                "Steps": {
+                    "description": "number of bins to merge",
+                    "type": "integer"
+                }
+            },
+            "additionalProperties": false
         },
         "smoothing_setting": {
             "title": "Smoothing setting",


### PR DESCRIPTION
Adding functionality to re-bin during template post-processing.

_to-do:_
- decide whether to support index- or coordinate-based rebinning (or both?)
- understand typing of histogram re-assignment
- converge on config format
- tests
- figure out relation to `Binning` config setting: this is only cosmetic (for plots) for histogram inputs; for ntuple inputs it would no longer correspond to the actual binning needed in plots if rebinning is used -> automatically convert internally?

resolves #412