### PR TITLE
build: drop explicit awkward dependency

### DIFF
--- a/.github/workflows/dependencies-head.yml
+++ b/.github/workflows/dependencies-head.yml
@@ -32,31 +32,6 @@ jobs:
       run: |
         python -m pytest -r sx
 
-  awkward:
-
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-latest]
-        python-version: ['3.11']
-
-    steps:
-    - uses: actions/checkout@v3
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
-      with:
-        python-version: ${{ matrix.python-version }}
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip setuptools wheel
-        python -m pip install --ignore-installed --upgrade -q --no-cache-dir -e .[test]
-        python -m pip uninstall --yes awkward
-        python -m pip install --upgrade --no-cache-dir git+https://github.com/scikit-hep/awkward-1.0.git
-        python -m pip list
-    - name: Test with pytest
-      run: |
-        python -m pytest -r sx
-
   uproot:
 
     runs-on: ${{ matrix.os }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,8 +37,6 @@ python_version = "3.9"
 [[tool.mypy.overrides]]
 module = [
     "uproot",
-    "awkward",
-    "awkward._v2",
     "pyhf",
     "matplotlib.*",
     "iminuit",

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,7 +25,6 @@ python_requires = >=3.8
 install_requires =
     pyhf[minuit]~=0.7.0  # model.config.suggested_fixed / .par_names API changes, set_poi(None)
     boost_histogram>=1.0.0  # subclassing with family, 1.02 for stdev scaling fix (currently not needed)
-    awkward>=1.8  # _v2 API in submodule
     tabulate>=0.8.1  # multiline text
     matplotlib>=3.5.0  # layout kwarg for subplots
     # below are direct dependencies of cabinetry, which are also included via pyhf[iminuit]

--- a/src/cabinetry/tabulate.py
+++ b/src/cabinetry/tabulate.py
@@ -4,7 +4,6 @@ import logging
 import pathlib
 from typing import Any, Dict, List, Optional, Union
 
-import awkward as ak
 import numpy as np
 import pyhf
 import tabulate
@@ -285,9 +284,12 @@ def yields(
 
     if per_channel:
         # yields per channel
-        model_yields_per_channel = np.sum(
-            ak.from_iter(model_prediction.model_yields), axis=-1
-        ).tolist()
+        n_channels = len(model_prediction.model.config.channels)
+        model_yields_per_channel = [
+            np.sum(model_prediction.model_yields[i_chan], axis=-1).tolist()
+            for i_chan in range(n_channels)
+        ]
+
         data_per_channel = [sum(d) for d in data_yields]
         per_channel_table = _yields_per_channel(
             model_prediction.model,


### PR DESCRIPTION
Following #408 there was only one place left where `awkward` was used in the `cabinetry` code base, in `cabinetry.tabulate`. The use of awkward there was not crucial, so this is replaced by pure `numpy` here. This means that the explicit `awkward` dependency can be dropped from `cabinetry`. It still enters in `cabinetry[contrib]` via `uproot`.

```
* drop explicit dependency on awkward
* remove awkward HEAD tests from nightly CI tests
```