### PR TITLE
feat: enable template histogram creation and collection to accept list of tasks

### DIFF
--- a/example.py
+++ b/example.py
@@ -17,7 +17,20 @@ if __name__ == "__main__":
     cabinetry.configuration.print_overview(config)
 
     # create template histograms
-    cabinetry.templates.build(config, method="uproot")
+    from dask.distributed import Client, LocalCluster, wait
+
+    def produce_single_template(template):
+        cabinetry.templates.build(config, template_list=[template])
+
+    template_list = cabinetry.route.required_templates(config)
+
+    with LocalCluster(n_workers=2) as cluster:
+        client = Client(cluster)
+        wait(client.map(produce_single_template, template_list))
+
+    # cabinetry.templates.build(config, template_list=template_list)
+
+    raise SystemExit
 
     # perform histogram post-processing
     cabinetry.templates.postprocess(config)


### PR DESCRIPTION
This updates the `templates.build`, `templates.collect`, and `templates.postprocess` implementations to accept a list of templates to produce via a new `template_list` keyword argument. The full list can be obtained via `route.required_templates`. By default, all templates will still be processed.

This allows users to parallelize the template histogram production / collection, partially addressing #401. An example of this would be the following:
```python
from dask.distributed import Client, LocalCluster, wait

def produce_single_template(template):
    cabinetry.templates.build(config, template_list=[template])

template_list = cabinetry.route.required_templates(config)

with LocalCluster(n_workers=2) as cluster:
    client = Client(cluster)
    wait(client.map(produce_single_template, template_list))
```
compared to the non-parallelized version, which is unchanged:
```python
cabinetry.templates.build(config
```

**breaking change:**
- renamed `route.apply_to_templates` to `route.apply_to_templates` and changed signature: now takes a list of tasks, which can be generated by `route.required_templates`

```
* templates.build, templates.collect, and templates.postprocess now accept a list of tasks
```