### PR TITLE
build: temporarily restrict latest typeguard to avoid dependency clash

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ extras_require["test"] = sorted(
             "mypy",
             "types-tabulate",
             "types-PyYAML",
-            "typeguard>=4.0.0",  # cabinetry#391
+            "typeguard>=4.0.0,!=4.1.0,!=4.1.1",  # cabinetry#391, cabinetry#428
             "black",
         ]
     )

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ extras_require["test"] = sorted(
             "mypy",
             "types-tabulate",
             "types-PyYAML",
-            "typeguard>=4.0.0,!=4.1.0,!=4.1.1",  # cabinetry#391, cabinetry#428
+            "typeguard>=4.0.0,!=4.0.1,!=4.1.0,!=4.1.1",  # cabinetry#391, cabinetry#428
             "black",
         ]
     )


### PR DESCRIPTION
Context in #428: the latest `typeguard` releases (`>=4.0.1`) require `typing_extension>=4.7.0`, which are versions beyond the cap put on it by Tensorflow. The next Tensorflow release removes that cap. In the meantime, restrict the specific `typeguard` versions that cause the clash. This will be reverted after the Tensorflow release.

```
* temporarily restrict typeguard versions to avoid dependency clash via typing_extensions due to Tensorflow
```