### PR TITLE
Expanded normalization modifiers

### DIFF
--- a/src/cabinetry/configuration.py
+++ b/src/cabinetry/configuration.py
@@ -231,10 +231,10 @@ def histogram_is_needed(
         else:
             # handle non-nominal, non-data histograms
             # this assumes that the systematic dict satisfies config schema requirements
-            if systematic["Type"] == "Normalization":
+            if systematic[template] == "Normalization":
                 # no histogram needed for normalization variation
                 histo_needed = False
-            elif systematic["Type"] == "NormPlusShape":
+            elif systematic["Type"] == "NormPlusShape" or systematic["Type"] == "Normalization":
                 # for a variation defined via a template, a histogram is needed (if
                 # sample is affected in region)
                 histo_needed = region_contains_modifier(region, systematic)

--- a/src/cabinetry/workspace.py
+++ b/src/cabinetry/workspace.py
@@ -98,7 +98,9 @@ class WorkspaceBuilder:
         """Returns a normalization modifier (OverallSys in `HistFactory`).
 
         Args:
-            systematic (Dict[str, Any]): systematic for which modifier is constructed
+            region (Dict[str, Any]): region the systematic variation acts in
+            sample (Dict[str, Any]): sample the systematic variation acts on
+            systematic (Dict[str, Any]): the systematic variation under consideration
 
         Returns:
             Dict[str, Any]: single `normsys` modifier for ``pyhf`` workspace

--- a/src/cabinetry/workspace.py
+++ b/src/cabinetry/workspace.py
@@ -91,8 +91,10 @@ class WorkspaceBuilder:
                 )
         return modifiers
 
-    @staticmethod
-    def normalization_modifier(systematic: Dict[str, Any]) -> Dict[str, Any]:
+    # @staticmethod -- VK: had to disable that to pass self
+    def normalization_modifier(
+        self, region: Dict[str, Any], sample: Dict[str, Any], systematic: Dict[str, Any]
+    ) -> Dict[str, Any]:
         """Returns a normalization modifier (OverallSys in `HistFactory`).
 
         Args:
@@ -107,14 +109,66 @@ class WorkspaceBuilder:
         modifier = {}
         modifier.update({"name": modifier_name})
         modifier.update({"type": "normsys"})
+        
+        # VK: need to add a check agains Up/Down type agreement -- maybe at the level of the config file creation/validation
+        if systematic.get("Up").get("Normalization"):
+            if systematic.get("Up").get("Symmetrize"):
+                raise NotImplementedError("Symmetrization should happen on the Down variation.")
+            elif systematic.get("Down").get("Symmetrize"):
+                norm_effect_up = 1 + systematic["Up"]["Normalization"]
+                norm_effect_down = 1 - systematic["Up"]["Normalization"]
+            else:
+                norm_effect_up = 1 + systematic["Up"]["Normalization"]
+                norm_effect_down = 1 + systematic["Down"]["Normalization"]
+        else:
+            # need to calculate the normalisation factor from the histograms
+            if systematic.get("Up").get("Symmetrize"):
+                raise NotImplementedError("Symmetrization should happen on the Down variation.")
+            # load the up systematic variation histogram
+            histogram_up = histo.Histogram.from_config(
+                self.histogram_folder,
+                region,
+                sample,
+                systematic,
+                template="Up",
+                modified=True,
+            )
+            # also need the nominal histogram
+            histogram_nominal = histo.Histogram.from_config(
+                self.histogram_folder, region, sample, {}, modified=True
+            )
+
+            if systematic.get("Down").get("Symmetrize"):
+                # symmetrization according to "method 1" from issue #26:
+                # first normalization, then symmetrization
+
+                # normalize the variation to the same yield as nominal
+                norm_effect = histogram_up.normalize_to_yield(histogram_nominal)
+                norm_effect_up = norm_effect
+                norm_effect_down = 2 - norm_effect
+            else:
+                histogram_down = histo.Histogram.from_config(
+                    self.histogram_folder,
+                    region,
+                    sample,
+                    systematic,
+                    template="Down",
+                    modified=True,
+                )
+                
+                norm_effect_up = sum(histogram_up.yields) / sum(histogram_nominal.yields)
+                norm_effect_down = sum(histogram_down.yields) / sum(histogram_nominal.yields)
+        
+        # update the modifier data
         modifier.update(
             {
                 "data": {
-                    "hi": 1 + systematic["Up"]["Normalization"],
-                    "lo": 1 + systematic["Down"]["Normalization"],
+                    "hi": norm_effect_up,
+                    "lo": norm_effect_down,
                 }
             }
         )
+
         return modifier
 
     def normplusshape_modifiers(
@@ -240,7 +294,7 @@ class WorkspaceBuilder:
                         f"adding OverallSys {systematic['Name']} to sample"
                         f" {sample['Name']} in region {region['Name']}"
                     )
-                    modifiers.append(self.normalization_modifier(systematic))
+                    modifiers.append(self.normalization_modifier(region, sample, systematic))
                 elif systematic["Type"] == "NormPlusShape":
                     # two modifiers are needed - an OverallSys for the norm effect,
                     # and a HistoSys for the shape variation


### PR DESCRIPTION
This PR expands the usage and notion of normalization modifiers. Now normalization modifiers can also come from weight or tree variations. For example, a weight-based systematic can define a variation from which a normalization effect is calculated. 

This PR also allows the symmetrization of normalization systematics.

As a side note, it would be good to add a safety check during the creation of the configuration file in order to **not** allow different properties of _Up_ and _Down_ variations. For example, we might **not** want to allow:
```python
  - Name: "my_systematic"
    Up:
      Weight: "<up-weight-string>"
    Down:
      Normalization: <up-factor>
    Type: "Normalization"
```