### PR TITLE
feat: turn warnings about missing post-processed histograms into info messages

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ extras_require["test"] = sorted(
             "mypy",
             "types-tabulate",
             "types-PyYAML",
-            "typeguard>=4.0.0,!=4.0.1,!=4.1.0,!=4.1.1",  # cabinetry#391, cabinetry#428
+            "typeguard>=4.0.0,!=4.0.1,!=4.1.*",  # cabinetry#391, cabinetry#428
             "black",
         ]
     )

--- a/src/cabinetry/histo.py
+++ b/src/cabinetry/histo.py
@@ -79,11 +79,10 @@ class Histogram(bh.Histogram, family=cabinetry):
         if modified:
             histo_path_modified = histo_path.parent / (histo_path.name + "_modified")
             if not histo_path_modified.with_suffix(".npz").exists():
-                log.warning(
-                    f"the modified histogram {histo_path_modified.with_suffix('.npz')} "
-                    "does not exist"
+                log.info(
+                    f"no modified histogram {histo_path_modified.with_suffix('.npz')} "
+                    "found, loading un-modified histogram"
                 )
-                log.warning("loading the un-modified histogram instead!")
             else:
                 histo_path = histo_path_modified
         histogram_npz = np.load(histo_path.with_suffix(".npz"))

--- a/tests/test_histo.py
+++ b/tests/test_histo.py
@@ -122,13 +122,11 @@ def test_Histogram_from_path(tmp_path, caplog, example_histograms, histogram_hel
 
     # try loading a modified one, without success since it does not exist
     h_from_path_modified = histo.Histogram.from_path(tmp_path, modified=True)
-    expected_warning = (
-        f"the modified histogram {str(tmp_path)}_modified.npz does not exist"
+    expected_info = (
+        f"no modified histogram {str(tmp_path)}_modified.npz found, "
+        "loading un-modified histogram"
     )
-    assert expected_warning in [rec.message for rec in caplog.records]
-    assert "loading the un-modified histogram instead!" in [
-        rec.message for rec in caplog.records
-    ]
+    assert expected_info in [rec.message for rec in caplog.records]
     caplog.clear()
 
     # successfully load a modified histogram


### PR DESCRIPTION
The `WARNING` log level when histogram post-processing is not called seemed a bit too high. This is now an `INFO` level message instead.

Extending the `typeguard` version restrictions to handle #428.

resolves #432

```
* lower warning-level messages when histogram post-processing is not used to info-level messages
* temporarily restrict more typeguard versions to avoid typing_extensions conflict due to TensorFlow
```