### PR TITLE
feat: support SamplePath overrides for histogram inputs

### DIFF
--- a/docs/core.rst
+++ b/docs/core.rst
@@ -121,7 +121,7 @@ VariationPath
 """""""""""""
 
 Each systematic template can set the value for the ``{VariationPath}`` placeholder via the ``VariationPath`` setting.
-The ``SamplePath`` setting cannot be overridden.
+The ``RegionPath`` setting cannot be overridden.
 
 An example
 """"""""""

--- a/docs/core.rst
+++ b/docs/core.rst
@@ -116,13 +116,12 @@ SamplePath
 
 The ``SamplePath`` setting sets the value for the ``{SamplePath}`` placeholder.
 In contrast to the ntuple case, this value cannot be a list of strings.
-It also cannot be overridden on a per-systematic basis, just like ``RegionPath``.
 
 VariationPath
 """""""""""""
 
 Each systematic template can set the value for the ``{VariationPath}`` placeholder via the ``VariationPath`` setting.
-``RegionPath`` and ``SamplePath`` settings cannot be overridden.
+The ``SamplePath`` setting cannot be overridden.
 
 An example
 """"""""""

--- a/src/cabinetry/contrib/histogram_creator.py
+++ b/src/cabinetry/contrib/histogram_creator.py
@@ -1,11 +1,15 @@
 """Creates histograms from ntuples with uproot."""
 
+import logging
 import pathlib
 from typing import List, Optional
 
 import boost_histogram as bh
 import numpy as np
 import uproot
+
+
+log = logging.getLogger(__name__)
 
 
 def with_uproot(
@@ -50,6 +54,8 @@ def with_uproot(
         # no weight specified, all weights are 1.0
         weight_is_expression = False
         weight = "1.0"
+
+    log.debug(f"reading input ntuples {paths_with_trees}")
 
     if weight_is_expression:
         # need to read observables and weights

--- a/src/cabinetry/contrib/histogram_reader.py
+++ b/src/cabinetry/contrib/histogram_reader.py
@@ -1,7 +1,12 @@
 """Reads histograms with uproot."""
 
+import logging
+
 import boost_histogram as bh
 import uproot
+
+
+log = logging.getLogger(__name__)
 
 
 def with_uproot(histo_path: str) -> bh.Histogram:
@@ -14,5 +19,6 @@ def with_uproot(histo_path: str) -> bh.Histogram:
     Returns:
         bh.Histogram: histogram containing data
     """
+    log.debug(f"reading input histogram {histo_path}")
     hist = uproot.open(histo_path).to_boost()
     return hist

--- a/src/cabinetry/templates/builder.py
+++ b/src/cabinetry/templates/builder.py
@@ -29,9 +29,9 @@ def _ntuple_paths(
     A path is built starting from the path specified in the general options in the
     configuration file. This path can contain placeholders for region- and sample-
     specific overrides, via ``{Region}`` and ``{Sample}``. For non-nominal templates, it
-    is possible to override the sample path if the ``SamplePath`` option is specified
-    for the template. If ``SamplePath`` is a list, return a list of paths (one per
-    entry in the list).
+    is possible to override the path if the ``RegionPath`` or ``SamplePath`` options are
+    specified for the template. If ``SamplePath`` is a list, return a list of paths
+    (one per entry in the list).
 
     Args:
         general_path (str): path specified in general settings, with sections that can


### PR DESCRIPTION
As discussed in #435 and originally via #433, `SamplePath` overrides are needed to provide additional flexibility for histogram inputs. This adds support for such overrides. For easier debugging, a new `DEBUG` level message is also added to report the location of histogram and ntuple inputs.

```
* support SamplePath overrides when using histogram inputs
* update documentation for histogram inputs
* add debug-level log message with paths to ntuple and histogram inputs
```