### PR TITLE
chore: updating version to 0.6.0

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = cabinetry
-version = 0.5.2
+version = 0.6.0
 author = Alexander Held
 description = design and steer profile likelihood fits
 long_description = file: README.md

--- a/src/cabinetry/__init__.py
+++ b/src/cabinetry/__init__.py
@@ -35,7 +35,7 @@ def __dir__() -> List[str]:
     return __all__
 
 
-__version__ = "0.5.2"
+__version__ = "0.6.0"
 
 
 def set_logging() -> None:


### PR DESCRIPTION
Updating to version `0.6.0`, which brings Python 3.11 support and drops Python 3.7. It also adds support for custom colors in data/MC plots, more flexibility for histogram input paths, speeds up post-fit yield uncertainty calculations and includes a few bug fixes.

```
* updating version to 0.6.0
```