### PR TITLE
build: relax typeguard constraints following TensorFlow release

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -55,6 +55,8 @@ jobs:
     - name: Test with pytest, generate coverage report (skipping typeguard)
       if: matrix.python-version == '3.8'
       run: |
+        # https://github.com/scikit-hep/cabinetry/issues/428
+        pip install --upgrade typing_extensions
         # skip typeguard for coverage https://github.com/agronholm/typeguard/issues/356
         pytest --runslow --cov-report=xml --typeguard-packages=""
     - name: Test with pytest

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ extras_require["test"] = sorted(
             "mypy",
             "types-tabulate",
             "types-PyYAML",
-            "typeguard>=4.0.0,!=4.0.1,!=4.1.*",  # cabinetry#391, cabinetry#428
+            "typeguard>=4.0.0",  # cabinetry#391
             "black",
         ]
     )


### PR DESCRIPTION
To avoid a `typing_extension` clash caused by TensorFlow, #429 restricted the `typeguard` version listed in the `test` setup extra. Now that an updated TensorFlow version is available, which fixes this clash, the `typeguard` version restriction can be relaxed again.

The `typing-extensions` cap introduced in `tensorflow-probability` has been fixed, but the versions with the fix are Python 3.9+ and therefore cause issues in the CI for 3.8. To avoid this, upgrade the `typing_extensions` version in the relevant Python 3.8 CI.

resolves #428

```
* relax version constraint on typeguard as latest TensorFlow release no longer causes dependency clash
* upgrade typing-extensions version in Python 3.8 CI to circumvent dependency clash
```