### PR TITLE
docs: add award number for second phase of IRIS-HEP

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,5 +78,6 @@ Find more information in the [documentation](https://cabinetry.readthedocs.io/) 
 ## Acknowledgements
 
 [![NSF-1836650](https://img.shields.io/badge/NSF-1836650-blue.svg)](https://nsf.gov/awardsearch/showAward?AWD_ID=1836650)
+[![PHY-2323298](https://img.shields.io/badge/PHY-2323298-blue.svg)](https://nsf.gov/awardsearch/showAward?AWD_ID=2323298)
 
-This work was supported by the U.S. National Science Foundation (NSF) cooperative agreement [OAC-1836650 (IRIS-HEP)](https://nsf.gov/awardsearch/showAward?AWD_ID=1836650).
+This work was supported by the U.S. National Science Foundation (NSF) cooperative agreements [OAC-1836650](https://nsf.gov/awardsearch/showAward?AWD_ID=1836650) and [PHY-2323298](https://nsf.gov/awardsearch/showAward?AWD_ID=2323298) (IRIS-HEP).

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -43,4 +43,4 @@ Presentations of cabinetry
 
 Acknowledgements
 ----------------
-This work was supported by the U.S. National Science Foundation (NSF) cooperative agreement `OAC-1836650 (IRIS-HEP) <https://nsf.gov/awardsearch/showAward?AWD_ID=1836650>`_.
+This work was supported by the U.S. National Science Foundation (NSF) cooperative agreements `OAC-1836650 <https://nsf.gov/awardsearch/showAward?AWD_ID=1836650>`_ and `PHY-2323298 <https://nsf.gov/awardsearch/showAward?AWD_ID=2323298>`_ (IRIS-HEP).


### PR DESCRIPTION
Adding award number [PHY-2323298](https://www.nsf.gov/awardsearch/showAward?AWD_ID=2323298) to both readme and documentation.

```
* add award number for second phase of IRIS-HEP to readme and documentation
```