### PR TITLE
style: apply Black's 2024 style

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -42,9 +42,9 @@ jobs:
         flake8 src/cabinetry --select=E9,F63,F7,F82 --show-source
         # check for additional issues flagged by flake8
         flake8
-    # - name: Format with Black
-    #   run: |
-    #     black --check --diff --verbose .
+    - name: Format with Black
+      run: |
+        black --check --diff --verbose .
     - name: Run example
       run: |
         python utils/create_ntuples.py

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,10 +1,10 @@
 repos:
 -   repo: https://github.com/psf/black-pre-commit-mirror
-    rev: 23.3.0
+    rev: 24.1.1
     hooks:
     -   id: black
 -   repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.3.0
+    rev: v1.8.0
     hooks:
     -   id: mypy
         name: mypy with Python 3.9
@@ -18,17 +18,17 @@ repos:
         additional_dependencies: ["numpy>=1.22", "boost-histogram>=1.0.1", "click>=8", "types-tabulate", "types-PyYAML"]
         args: ["--python-version=3.11"]
 -   repo: https://github.com/pycqa/flake8
-    rev: 6.0.0
+    rev: 7.0.0
     hooks:
     -   id: flake8
         additional_dependencies: [flake8-bugbear, flake8-import-order, flake8-print]
 -   repo: https://github.com/asottile/pyupgrade
-    rev: v3.4.0
+    rev: v3.15.0
     hooks:
     -   id: pyupgrade
         args: ["--py38-plus"]
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.4.0
+    rev: v4.5.0
     hooks:
     -   id: check-added-large-files
         args: ["--maxkb=100"]
@@ -40,7 +40,7 @@ repos:
         # configuration duplicated in setup.cfg
         args: ["--match=(?!setup|example).*\\.py'", "--match-dir='^(?!(tests|utils|docs)).*'", "--convention=google"]
 -   repo: https://github.com/codespell-project/codespell
-    rev: v2.2.4
+    rev: v2.2.6
     hooks:
     -   id: codespell
         args: ["-L", "hist", "src", "tests", "utils", "docs/*rst"]

--- a/src/cabinetry/cli/__init__.py
+++ b/src/cabinetry/cli/__init__.py
@@ -348,10 +348,7 @@ def data_mc(
     help='format in which to save the table (default: "simple")',
 )
 def yields(
-    ws_spec: io.TextIOWrapper,
-    postfit: bool,
-    tablefolder: str,
-    tablefmt: str,
+    ws_spec: io.TextIOWrapper, postfit: bool, tablefolder: str, tablefmt: str
 ) -> None:
     """Creates yield tables of fit model and observed data.
 
@@ -366,10 +363,7 @@ def yields(
 
     model_prediction = cabinetry_model_utils.prediction(model, fit_results=fit_results)
     cabinetry_tabulate.yields(
-        model_prediction,
-        data,
-        table_folder=tablefolder,
-        table_format=tablefmt,
+        model_prediction, data, table_folder=tablefolder, table_format=tablefmt
     )
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -402,13 +402,7 @@ def example_spec_zero_staterror():
             }
         ],
         "measurements": [
-            {
-                "config": {
-                    "parameters": [],
-                    "poi": "mu",
-                },
-                "name": "zero staterror",
-            }
+            {"config": {"parameters": [], "poi": "mu"}, "name": "zero staterror"}
         ],
         "observations": [{"data": [5, 0], "name": "SR"}],
         "version": "1.0.0",

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -200,7 +200,7 @@ def test_WorkspaceBuilder_normplusshape_modifiers(mock_histogram):
     # single bin, causing histosys being skipped
     modifiers = ws_builder.normplusshape_modifiers(region, sample, systematic)
     assert modifiers == [
-        {"name": "mod_name", "type": "normsys", "data": {"hi": 1.3, "lo": 0.7}},
+        {"name": "mod_name", "type": "normsys", "data": {"hi": 1.3, "lo": 0.7}}
     ]
 
 

--- a/tests/visualize/test_visualize_plot_model.py
+++ b/tests/visualize/test_visualize_plot_model.py
@@ -140,8 +140,7 @@ def test_data_mc(tmp_path, caplog):
     # negative bin yield
     histo_dict_list[0]["yields"] = [-50, -50]
     with pytest.raises(
-        ValueError,
-        match=r"abc total model yield has negative bin\(s\): \[-50, -45\]",
+        ValueError, match=r"abc total model yield has negative bin\(s\): \[-50, -45\]"
     ):
         plot_model.data_mc(
             histo_dict_list, total_model_unc_log, bin_edges_log, label="abc"

--- a/utils/create_histograms.py
+++ b/utils/create_histograms.py
@@ -1,4 +1,5 @@
 """Creates histograms used as input for a minimal example of cabinetry."""
+
 import os
 
 import boost_histogram as bh

--- a/utils/create_ntuples.py
+++ b/utils/create_ntuples.py
@@ -1,4 +1,5 @@
 """Creates ntuples used as input for a minimal example of cabinetry."""
+
 import os
 
 import matplotlib.pyplot as plt


### PR DESCRIPTION
Applying latest `black` formatting corresponding to the stable 2024 style with tag [24.1.0](https://github.com/psf/black/releases/tag/24.1.0). Running also once with `--skip-magic-trailing-comma` to adjust leftover commas. See also #383 for the previous version of this PR. Also adding `black` back to CI following the temporary removal in #459.

```
* apply Black's 2024 style
* updated pre-commit
* add back black to CI
```