### PR TITLE
fix: ranking plot axis range for normalization factors

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 -   repo: https://github.com/psf/black-pre-commit-mirror
-    rev: 24.1.1
+    rev: 24.2.0
     hooks:
     -   id: black
 -   repo: https://github.com/pre-commit/mirrors-mypy
@@ -23,7 +23,7 @@ repos:
     -   id: flake8
         additional_dependencies: [flake8-bugbear, flake8-import-order, flake8-print]
 -   repo: https://github.com/asottile/pyupgrade
-    rev: v3.15.0
+    rev: v3.15.1
     hooks:
     -   id: pyupgrade
         args: ["--py38-plus"]

--- a/src/cabinetry/visualize/plot_result.py
+++ b/src/cabinetry/visualize/plot_result.py
@@ -218,8 +218,20 @@ def ranking(
     ax_impact.set_xlim([-5, 5])
     ax_pulls.set_ylim([-1, num_pars])
 
-    # impact axis limits: need largest pre-fit impact
-    impact_max = np.amax(np.fabs(np.hstack((impact_prefit_up, impact_prefit_down))))
+    # impact axis limits: need largest impact
+    # consider also post-fit, normalization factors have no pre-fit impact defined
+    impact_max = np.amax(
+        np.fabs(
+            np.hstack(
+                (
+                    impact_prefit_up,
+                    impact_prefit_down,
+                    impact_postfit_up,
+                    impact_postfit_down,
+                )
+            )
+        )
+    )
     ax_impact.set_xlim([-impact_max * 1.1, impact_max * 1.1])
 
     # minor ticks


### PR DESCRIPTION
As flagged by #463, the impact axis range did not correctly take into account cases where the largest impacts were post-fit. This can happen in particular for normalization factors, which have no pre-fit impact defined.

```
* take into account both pre- and post-fit impacts when setting ranking plot axis range
* updated pre-commit
```