### PR TITLE
fix: explicitly convert parameter bounds to list of tuples

### DIFF
--- a/src/cabinetry/fit/__init__.py
+++ b/src/cabinetry/fit/__init__.py
@@ -184,7 +184,10 @@ def _fit_model_custom(
     # use parameter settings provided in function arguments if they exist, else defaults
     init_pars = init_pars or model.config.suggested_init()
     fix_pars = fix_pars or model.config.suggested_fixed()
-    par_bounds = par_bounds or model.config.suggested_bounds()
+    # ensure list of tuples, see https://github.com/scikit-hep/pyhf/issues/2462
+    par_bounds = par_bounds or [
+        tuple(bound) for bound in model.config.suggested_bounds()
+    ]
 
     labels = model.config.par_names
 
@@ -858,7 +861,10 @@ def limit(
     )
 
     # use par_bounds provided in function argument if they exist, else use default
-    par_bounds = par_bounds or model.config.suggested_bounds()
+    # ensure list of tuples, see https://github.com/scikit-hep/pyhf/issues/2462
+    par_bounds = par_bounds or [
+        tuple(bound) for bound in model.config.suggested_bounds()
+    ]
     if par_bounds[model.config.poi_index][0] < 0:
         # set lower POI bound to zero (for use with qmu_tilde)
         par_bounds[model.config.poi_index] = (


### PR DESCRIPTION
A bug fix in `typeguard` [4.2.0](https://github.com/agronholm/typeguard/releases/tag/4.2.0) started flagging a type inconsistency where `model.config.suggested_bounds()` contains elements that are lists instead of tuples with custom parameter bound configuration, see https://github.com/scikit-hep/pyhf/issues/2462. This fix here works around this by explicitly converting to a list of tuples for further use within `cabinetry`.

If the behavior in `pyhf` changes, this should be reverted / adjusted in the future.

```
* convert parameter bounds to list of tuples for consistent types when custom bounds are used
```