### PR TITLE
fix: histogram validation test for numpy 2.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,10 +1,10 @@
 repos:
 -   repo: https://github.com/psf/black-pre-commit-mirror
-    rev: 24.3.0
+    rev: 24.8.0
     hooks:
     -   id: black
 -   repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.9.0
+    rev: v1.11.1
     hooks:
     -   id: mypy
         name: mypy with Python 3.9
@@ -18,17 +18,17 @@ repos:
         additional_dependencies: ["numpy>=1.22", "boost-histogram>=1.0.1", "click>=8", "types-tabulate", "types-PyYAML", "hist>=2.3.0"]
         args: ["--python-version=3.12"]
 -   repo: https://github.com/pycqa/flake8
-    rev: 7.0.0
+    rev: 7.1.1
     hooks:
     -   id: flake8
         additional_dependencies: [flake8-bugbear, flake8-import-order, flake8-print]
 -   repo: https://github.com/asottile/pyupgrade
-    rev: v3.15.1
+    rev: v3.17.0
     hooks:
     -   id: pyupgrade
         args: ["--py38-plus"]
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.5.0
+    rev: v4.6.0
     hooks:
     -   id: check-added-large-files
         args: ["--maxkb=100"]
@@ -40,7 +40,7 @@ repos:
         # configuration duplicated in setup.cfg
         args: ["--match=(?!setup|example).*\\.py'", "--match-dir='^(?!(tests|utils|docs)).*'", "--convention=google"]
 -   repo: https://github.com/codespell-project/codespell
-    rev: v2.2.6
+    rev: v2.3.0
     hooks:
     -   id: codespell
         args: ["-L", "hist", "src", "tests", "utils", "docs/*rst"]

--- a/src/cabinetry/histo.py
+++ b/src/cabinetry/histo.py
@@ -212,7 +212,7 @@ class Histogram(bh.Histogram, family=cabinetry):
 
         # check whether there are any bins with ill-defined stat. uncertainty
         # but non-empty yield, those deserve a closer look
-        not_empty_but_nan = [b for b in nan_pos if b not in empty_bins]
+        not_empty_but_nan = np.asarray([b for b in nan_pos if b not in empty_bins])
         if len(not_empty_but_nan) > 0:
             log.warning(
                 f"{name} has non-empty bins with ill-defined stat. unc.: "


### PR DESCRIPTION
The histogram validation prints indices slightly differently in `numpy` 2.0 (`[np.int64(1)]`), which caused a test to fail. This is fixed here.


```
* fix the way histogram indices are represented for numpy 2.0
* updated pre-commit
```