### PR TITLE
feat: allow custom top-level properties in configuration schema

### DIFF
--- a/src/cabinetry/schemas/config.json
+++ b/src/cabinetry/schemas/config.json
@@ -422,5 +422,5 @@
             "additionalProperties": false
         }
     },
-    "additionalProperties": false
+    "additionalProperties": true
 }

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -23,12 +23,13 @@ def test_validate():
     }
     assert configuration.validate(config_valid)
 
-    # not exactly one data sample
+    # not exactly one data sample, custom additional top-level properties
     config_multiple_data_samples = {
         "General": {"Measurement": "", "HistogramFolder": "", "InputPath": ""},
         "Regions": [{"Name": "", "Filter": "", "Variable": "", "Binning": [0, 1]}],
         "Samples": [{"Name": "", "Tree": ""}],
         "NormFactors": [{"Name": ""}],
+        "ABC": [],
     }
     with pytest.raises(
         NotImplementedError, match="can only handle cases with exactly one data sample"


### PR DESCRIPTION
The config schema has previously been very restrictive, not allowing unknown top-level properties. The intention was to help catch possible spelling mistakes, but at the top level this seems less likely and restricts the config when users may want to add custom information to the same file. To facilitate such use cases, allow for custom keys at the top level.

```
* allow custom top-level properties in configuration schema
```