### PR TITLE
ci: drop mypy checks with Python 3.9

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,12 +7,6 @@ repos:
     rev: v1.11.1
     hooks:
     -   id: mypy
-        name: mypy with Python 3.9
-        files: src/cabinetry
-        additional_dependencies: ["numpy>=1.22", "boost-histogram>=1.0.1", "click>=8", "types-tabulate", "types-PyYAML", "hist>=2.3.0"]
-        # numpy 1.25 is no longer compatible with Python 3.8, so use Python >=3.9 for type checking
-        args: ["--python-version=3.9"]
-    -   id: mypy
         name: mypy with Python 3.12
         files: src/cabinetry
         additional_dependencies: ["numpy>=1.22", "boost-histogram>=1.0.1", "click>=8", "types-tabulate", "types-PyYAML", "hist>=2.3.0"]


### PR DESCRIPTION
`mypy` started raising a few errors when run with Python 3.9 as observed in #488. Python 3.9 is already dropped as a supported version from `numpy` (see [NEP 29](https://numpy.org/neps/nep-0029-deprecation_policy.html)) since April 5 this year. Given that, this PR drops it from the pre-commit checks and just uses `mypy` with Python 3.12 instead (that check had already been running previously in addition).

```
* drop mypy in Python 3.9 mode from pre-commit
* keep mypy in Python 3.12 mode
```