### PR TITLE
feat: limit parameter variations in rankings to stay within parameter bounds

### DIFF
--- a/src/cabinetry/fit/__init__.py
+++ b/src/cabinetry/fit/__init__.py
@@ -588,6 +588,10 @@ def ranking(
     init_pars = init_pars or model.config.suggested_init()
     fix_pars = fix_pars or model.config.suggested_fixed()
 
+    par_bounds = par_bounds or [
+        tuple(bound) for bound in model.config.suggested_bounds()
+    ]
+
     all_impacts = []
     for i_par, label in enumerate(labels):
         if i_par == poi_index:
@@ -613,9 +617,6 @@ def ranking(
                 log.debug(f"impact of {label} is zero, skipping fit")
                 parameter_impacts.append(0.0)
             else:
-                par_bounds = par_bounds or [
-                    tuple(bound) for bound in model.config.suggested_bounds()
-                ]
                 if not par_bounds[i_par][0] <= np_val <= par_bounds[i_par][1]:
                     np_val = min(
                         max(np_val, par_bounds[i_par][0]), par_bounds[i_par][1]

--- a/src/cabinetry/fit/__init__.py
+++ b/src/cabinetry/fit/__init__.py
@@ -613,6 +613,13 @@ def ranking(
                 log.debug(f"impact of {label} is zero, skipping fit")
                 parameter_impacts.append(0.0)
             else:
+                par_bounds = par_bounds or [
+                    tuple(bound) for bound in model.config.suggested_bounds()
+                ]
+                if not par_bounds[i_par][0] <= np_val <= par_bounds[i_par][1]:
+                    np_val = min(
+                        max(np_val, par_bounds[i_par][0]), par_bounds[i_par][1]
+                    )
                 init_pars_ranking = init_pars.copy()
                 init_pars_ranking[i_par] = np_val  # value of current nuisance parameter
                 fit_results_ranking = _fit_model(


### PR DESCRIPTION
As identified by @malin-horstmann, we can run into scenarios where the ranking will attempt to vary parameters beyond their bounds. This can happen with parameters that have asymmetric uncertainties when only a symmetric estimate was done from the Hessian (for `shapesys` in particular this is likely to happen).

This PR limits the variations to stick within bounds. Things to think about before finishing this:
- raise a warning? (seems useful, but hard to miss in verbose ranking output)
- allow for a way to propagate MINOS uncertainties through instead?
- visually flag such cases in the plot?

The CI fail is currently expected (bounds kwarg changes).

```
* force parameter variations in ranking to stay within parameter bounds
```