### PR TITLE
docs: Add CITATION.cff file and update vCHEP DOI

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,51 @@
+cff-version: 1.2.0
+message: "Please cite the following works when using this software."
+type: software
+authors:
+- family-names: "Held"
+  given-names: "Alexander"
+  orcid: "https://orcid.org/0000-0002-8924-5885"
+  affiliation: "University of Wisconsin-Madison"
+title: "cabinetry: v0.6.0"
+version: 0.6.0
+doi: 10.5281/zenodo.4742752
+repository-code: "https://github.com/scikit-hep/cabinetry/releases/tag/v0.6.0"
+url: "https://cabinetry.readthedocs.io/"
+keywords:
+  - python
+  - fitting
+  - physics
+  - profile likelihood
+license: "BSD-3-Clause"
+abstract: |
+  Statistical models in [HistFactory](https://cds.cern.ch/record/1456844)
+  format can be built by `cabinetry` from instructions in a declarative
+  configuration.
+  `cabinetry` makes heavy use of [`pyhf`](https://pyhf.readthedocs.io/) for
+  statistical inference, and provides additional utilities to help study and
+  disseminate fit results.
+  This includes commonly used visualizations.
+  Due to its modular approach, analyzers are free to use all of `cabinetry`'s
+  functionality or only some pieces.
+  `cabinetry` can be used for inference and visualization with any
+  `pyhf`-compatible model, whether it was built with `cabinetry` or not.
+references:
+  - type: article
+    authors:
+    - family-names: "Held"
+      given-names: "Alexander"
+      orcid: "https://orcid.org/0000-0002-8924-5885"
+      affiliation: "New York University"
+    - family-names: "Cranmer"
+      given-names: "Kyle"
+      orcid: "https://orcid.org/0000-0002-5769-7094"
+      affiliation: "New York University"
+    title: "Building and steering binned template fits with cabinetry"
+    doi: 10.1051/epjconf/202125103067
+    url: "https://doi.org/10.1051/epjconf/202125103067"
+    year: 2021
+    publisher:
+      name: "EDP Sciences"
+    volume: 251
+    pages: 03067
+    journal: EPJ Web of Web of Conferences

--- a/README.md
+++ b/README.md
@@ -72,8 +72,7 @@ It requires additional dependencies obtained with `pip install cabinetry[contrib
 ## Documentation
 
 Find more information in the [documentation](https://cabinetry.readthedocs.io/) and tutorial material in the [cabinetry-tutorials](https://github.com/cabinetry/cabinetry-tutorials) repository.
-`cabinetry` is also described in a paper submitted to vCHEP 2021: [10.5281/zenodo.4627037](https://doi.org/10.5281/zenodo.4627037).
-
+`cabinetry` is also described in a paper submitted to vCHEP 2021: [10.1051/epjconf/202125103067](https://doi.org/10.1051/epjconf/202125103067).
 
 ## Acknowledgements
 


### PR DESCRIPTION
Resolves #492 

* Add CITATION.cff for the software and the vCHEP paper.
* Update vCHEP paper to use published DOI.
   - c.f. https://doi.org/10.1051/epjconf/202125103067

```console
$ pixi global install cffconvert
$ cffconvert --validate --infile CITATION.cff
Citation metadata are valid according to schema version 1.2.0.
```

![image](https://github.com/user-attachments/assets/cd508de9-46aa-4da1-8aa0-47fc8311a65a)
