### PR TITLE
feat: customizable confidence level for MINOS

### DIFF
--- a/src/cabinetry/fit/__init__.py
+++ b/src/cabinetry/fit/__init__.py
@@ -328,6 +328,8 @@ def _run_minos(
     minuit_obj: iminuit.Minuit,
     minos: Union[List[str], Tuple[str, ...]],
     labels: List[str],
+    *,
+    cl: Optional[float] = None,
 ) -> Dict[str, Tuple[float, float]]:
     """Determines parameter uncertainties for a list of parameters with MINOS.
 
@@ -337,6 +339,8 @@ def _run_minos(
         labels (List[str]]): names of all parameters known to ``iminuit``, these names
             are used in output (may be the same as the names under which ``iminiuit``
             knows parameters)
+        cl (Optional[float]), optional): confidence level for the confidence interval,
+            defaults to None (use ``iminuit`` default of 68.27%)
 
     Returns:
         Dict[str, Tuple[float, float]]: uncertainties indexed by parameter name
@@ -347,7 +351,7 @@ def _run_minos(
             log.warning(f"parameter {par_name} not found in model")
             continue
         log.info(f"running MINOS for {par_name}")
-        minuit_obj.minos(par_name)
+        minuit_obj.minos(par_name, cl=cl)
 
     minos_results = {}
 

--- a/tests/fit/test_fit.py
+++ b/tests/fit/test_fit.py
@@ -329,7 +329,7 @@ def test__run_minos(caplog):
     assert "b =  1.5909 -0.7262 +0.4738" in [rec.message for rec in caplog.records]
     caplog.clear()
 
-    # custom confidence interval
+    # custom confidence level
     minos_results = fit._run_minos(m, ["b"], ["a", "b"], minos_cl=0.95)
     assert np.allclose(minos_results["b"][0], -1.47037911)
     assert np.allclose(minos_results["b"][1], 0.81994008)

--- a/tests/fit/test_fit.py
+++ b/tests/fit/test_fit.py
@@ -317,6 +317,12 @@ def test__run_minos(caplog):
     assert "b =  1.5909 -0.7262 +0.4738" in [rec.message for rec in caplog.records]
     caplog.clear()
 
+    # custom confidence interval
+    minos_results = fit._run_minos(m, ["b"], ["a", "b"], cl=0.95)
+    assert np.allclose(minos_results["b"][0], -1.47037911)
+    assert np.allclose(minos_results["b"][1], 0.81994008)
+    caplog.clear()
+
     # unknown parameter, MINOS does not run
     m = iminuit.Minuit(func_to_minimize, [1.0, 1.0])
     m.errordef = 1

--- a/tests/fit/test_fit.py
+++ b/tests/fit/test_fit.py
@@ -101,7 +101,9 @@ def test__fit_model_pyhf(mock_minos, example_spec, example_spec_multibin):
 
     # including minos, one parameter is unknown
     model, data = model_utils.model_and_data(example_spec)
-    fit_results = fit._fit_model_pyhf(model, data, minos=["Signal strength", "abc"])
+    fit_results = fit._fit_model_pyhf(
+        model, data, minos=["Signal strength", "abc"], minos_cl=0.95
+    )
     assert fit_results.minos_uncertainty["Signal strength"] == (-0.1, 0.2)
     assert mock_minos.call_count == 1
     # first argument to minos call is the Minuit instance
@@ -110,6 +112,7 @@ def test__fit_model_pyhf(mock_minos, example_spec, example_spec_multibin):
         "Signal strength",
         "staterror_Signal-Region[0]",
     ]
+    assert mock_minos.call_args[0][3] == 0.95
     assert mock_minos.call_args[1] == {}
 
 
@@ -180,7 +183,9 @@ def test__fit_model_custom(mock_minos, example_spec, example_spec_multibin):
 
     # including minos
     model, data = model_utils.model_and_data(example_spec)
-    fit_results = fit._fit_model_custom(model, data, minos=["Signal strength"])
+    fit_results = fit._fit_model_custom(
+        model, data, minos=["Signal strength"], minos_cl=0.95
+    )
     assert fit_results.minos_uncertainty["Signal strength"] == (-0.1, 0.2)
     assert mock_minos.call_count == 1
     # first argument to minos call is the Minuit instance
@@ -189,6 +194,7 @@ def test__fit_model_custom(mock_minos, example_spec, example_spec_multibin):
         "Signal strength",
         "staterror_Signal-Region[0]",
     ]
+    assert mock_minos.call_args[0][3] == 0.95
     assert mock_minos.call_args[1] == {}
 
 
@@ -214,6 +220,7 @@ def test__fit_model(mock_pyhf, mock_custom, example_spec):
     assert mock_pyhf.call_args[0][1] == data
     assert mock_pyhf.call_args[1] == {
         "minos": None,
+        "minos_cl": None,
         "init_pars": None,
         "fix_pars": None,
         "par_bounds": None,
@@ -228,6 +235,7 @@ def test__fit_model(mock_pyhf, mock_custom, example_spec):
         model,
         data,
         minos=["Signal strength"],
+        minos_cl=0.95,
         init_pars=[1.5, 2.0],
         fix_pars=[False, True],
         par_bounds=[(0, 5), (0.1, 10.0)],
@@ -240,6 +248,7 @@ def test__fit_model(mock_pyhf, mock_custom, example_spec):
     assert mock_pyhf.call_args[0][1] == data
     assert mock_pyhf.call_args[1] == {
         "minos": ["Signal strength"],
+        "minos_cl": 0.95,
         "init_pars": [1.5, 2.0],
         "fix_pars": [False, True],
         "par_bounds": [(0, 5), (0.1, 10.0)],
@@ -256,6 +265,7 @@ def test__fit_model(mock_pyhf, mock_custom, example_spec):
     assert mock_custom.call_args[0][1] == data
     assert mock_custom.call_args[1] == {
         "minos": None,
+        "minos_cl": None,
         "init_pars": None,
         "fix_pars": None,
         "par_bounds": None,
@@ -270,6 +280,7 @@ def test__fit_model(mock_pyhf, mock_custom, example_spec):
         model,
         data,
         minos=["Signal strength"],
+        minos_cl=0.95,
         init_pars=[1.5, 2.0],
         fix_pars=[False, True],
         par_bounds=[(0, 5), (0.1, 10.0)],
@@ -283,6 +294,7 @@ def test__fit_model(mock_pyhf, mock_custom, example_spec):
     assert mock_custom.call_args[0][1] == data
     assert mock_custom.call_args[1] == {
         "minos": ["Signal strength"],
+        "minos_cl": 0.95,
         "init_pars": [1.5, 2.0],
         "fix_pars": [False, True],
         "par_bounds": [(0, 5), (0.1, 10.0)],
@@ -310,7 +322,7 @@ def test__run_minos(caplog):
     m.errordef = 1
     m.migrad()
 
-    minos_results = fit._run_minos(m, ["b"], ["a", "b"])
+    minos_results = fit._run_minos(m, ["b"], ["a", "b"], minos_cl=None)
     assert np.allclose(minos_results["b"][0], -0.72622053)
     assert np.allclose(minos_results["b"][1], 0.47381869)
     assert "running MINOS for b" in [rec.message for rec in caplog.records]
@@ -318,7 +330,7 @@ def test__run_minos(caplog):
     caplog.clear()
 
     # custom confidence interval
-    minos_results = fit._run_minos(m, ["b"], ["a", "b"], cl=0.95)
+    minos_results = fit._run_minos(m, ["b"], ["a", "b"], minos_cl=0.95)
     assert np.allclose(minos_results["b"][0], -1.47037911)
     assert np.allclose(minos_results["b"][1], 0.81994008)
     caplog.clear()
@@ -328,7 +340,7 @@ def test__run_minos(caplog):
     m.errordef = 1
     m.migrad()
 
-    minos_results = fit._run_minos(m, ["x2"], ["a", "b"])
+    minos_results = fit._run_minos(m, ["x2"], ["a", "b"], minos_cl=None)
     assert minos_results == {}
     assert [rec.message for rec in caplog.records] == [
         "parameter x2 not found in model",
@@ -406,6 +418,7 @@ def test_fit(mock_fit, mock_print, mock_gof):
             (model, data),
             {
                 "minos": None,
+                "minos_cl": None,
                 "init_pars": None,
                 "fix_pars": None,
                 "par_bounds": None,
@@ -443,6 +456,7 @@ def test_fit(mock_fit, mock_print, mock_gof):
         (model, data),
         {
             "minos": None,
+            "minos_cl": None,
             "init_pars": init_pars,
             "fix_pars": fix_pars,
             "par_bounds": par_bounds,
@@ -457,10 +471,11 @@ def test_fit(mock_fit, mock_print, mock_gof):
     assert fit_results.bestfit == [1.0]
 
     # parameters for MINOS
-    fit_results = fit.fit(model, data, minos=["abc"])
+    fit_results = fit.fit(model, data, minos=["abc"], minos_cl=0.95)
     assert mock_fit.call_count == 3
     assert mock_fit.call_args[1] == {
         "minos": ["abc"],
+        "minos_cl": 0.95,
         "init_pars": None,
         "fix_pars": None,
         "par_bounds": None,
@@ -470,10 +485,11 @@ def test_fit(mock_fit, mock_print, mock_gof):
         "custom_fit": False,
     }
     assert fit_results.bestfit == [1.0]
-    fit_results = fit.fit(model, data, minos="abc", custom_fit=True)
+    fit_results = fit.fit(model, data, minos="abc", minos_cl=0.95, custom_fit=True)
     assert mock_fit.call_count == 4
     assert mock_fit.call_args[1] == {
         "minos": ["abc"],
+        "minos_cl": 0.95,
         "init_pars": None,
         "fix_pars": None,
         "par_bounds": None,


### PR DESCRIPTION
Extend the `cabinetry.fit.fit` interface to set custom confidence levels. The interface follows `iminuit`'s [`minos`](https://scikit-hep.org/iminuit/reference.html#iminuit.Minuit.minos) API in terms of functionality but uses a `minos_cl` argument name instead.

```
* added customizable confidence level for MINOS to fit.fit
```