### PR TITLE
fix: type checking fixes for numpy 2.2 and add mypy back to pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,14 +3,14 @@ repos:
     rev: 25.1.0
     hooks:
     -   id: black
-# -   repo: https://github.com/pre-commit/mirrors-mypy
-#     rev: v1.14.1
-#     hooks:
-#     -   id: mypy
-#         name: mypy with Python 3.12
-#         files: src/cabinetry
-#         additional_dependencies: ["numpy>=1.22", "boost-histogram>=1.0.1", "click>=8", "types-tabulate", "types-PyYAML", "hist>=2.3.0"]
-#         args: ["--python-version=3.12"]
+-   repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v1.14.1
+    hooks:
+    -   id: mypy
+        name: mypy with Python 3.12
+        files: src/cabinetry
+        additional_dependencies: ["numpy>=1.22", "boost-histogram>=1.0.1", "click>=8", "types-tabulate", "types-PyYAML", "hist>=2.3.0"]
+        args: ["--python-version=3.12"]
 -   repo: https://github.com/pycqa/flake8
     rev: 7.1.1
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@ repos:
     hooks:
     -   id: black
 -   repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.14.1
+    rev: v1.15.0
     hooks:
     -   id: mypy
         name: mypy with Python 3.12
@@ -12,7 +12,7 @@ repos:
         additional_dependencies: ["numpy>=1.22", "boost-histogram>=1.0.1", "click>=8", "types-tabulate", "types-PyYAML", "hist>=2.3.0"]
         args: ["--python-version=3.12"]
 -   repo: https://github.com/pycqa/flake8
-    rev: 7.1.1
+    rev: 7.1.2
     hooks:
     -   id: flake8
         additional_dependencies: [flake8-bugbear, flake8-import-order, flake8-print]

--- a/src/cabinetry/fit/__init__.py
+++ b/src/cabinetry/fit/__init__.py
@@ -1,7 +1,7 @@
 """High-level entry point for statistical inference."""
 
 import logging
-from typing import Any, Dict, List, Literal, Optional, Tuple, Union
+from typing import Any, cast, Dict, List, Literal, Optional, Tuple, Union
 
 import iminuit
 import numpy as np
@@ -779,7 +779,7 @@ def scan(
     for i_par, par_value in enumerate(scan_values):
         log.debug(f"performing fit with {par_name} = {par_value:.3f}")
         init_pars_scan = init_pars.copy()
-        init_pars_scan[par_index] = par_value
+        init_pars_scan[par_index] = cast(float, par_value)
         scan_fit_results = _fit_model(
             model,
             data,

--- a/src/cabinetry/model_utils.py
+++ b/src/cabinetry/model_utils.py
@@ -3,7 +3,17 @@
 from collections import defaultdict
 import json
 import logging
-from typing import Any, DefaultDict, Dict, List, NamedTuple, Optional, Tuple, Union
+from typing import (
+    Any,
+    cast,
+    DefaultDict,
+    Dict,
+    List,
+    NamedTuple,
+    Optional,
+    Tuple,
+    Union,
+)
 
 import numpy as np
 import pyhf
@@ -771,9 +781,13 @@ def _parameters_maximizing_constraint_term(
             else:
                 rescale_factors = [1.0] * n_params  # no rescaling by default
 
-            best_pars += (
-                np.asarray(aux_data[i_aux : i_aux + n_params]) / rescale_factors
-            ).tolist()
+            # manually cast, possible cause https://github.com/numpy/numpy/issues/27944
+            best_pars += cast(
+                List[float],
+                (
+                    np.asarray(aux_data[i_aux : i_aux + n_params]) / rescale_factors
+                ).tolist(),
+            )
             i_aux += n_params
 
         else:

--- a/src/cabinetry/model_utils.py
+++ b/src/cabinetry/model_utils.py
@@ -746,7 +746,7 @@ def _parameters_maximizing_constraint_term(
     Returns:
         List[float]: parameters maximizing the model constraint term
     """
-    best_pars = []  # parameters maximizing constraint term
+    best_pars: List[float] = []  # parameters maximizing constraint term
     i_aux = 0  # current position in auxiliary data list
     i_poisson = 0  # current position in list of Poisson rescale factors
 
@@ -771,9 +771,9 @@ def _parameters_maximizing_constraint_term(
             else:
                 rescale_factors = [1.0] * n_params  # no rescaling by default
 
-            best_pars += list(
+            best_pars += (
                 np.asarray(aux_data[i_aux : i_aux + n_params]) / rescale_factors
-            )
+            ).tolist()
             i_aux += n_params
 
         else:

--- a/src/cabinetry/workspace.py
+++ b/src/cabinetry/workspace.py
@@ -3,7 +3,7 @@
 import json
 import logging
 import pathlib
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Any, cast, Dict, List, Optional, Tuple, Union
 
 import pyhf
 
@@ -189,8 +189,9 @@ class WorkspaceBuilder:
         else:
             norm_effect_up = histogram_up.normalize_to_yield(histogram_nominal)
             norm_effect_down = histogram_down.normalize_to_yield(histogram_nominal)
-            histo_yield_up = histogram_up.yields.tolist()
-            histo_yield_down = histogram_down.yields.tolist()
+            # manually cast due to https://github.com/numpy/numpy/issues/27944
+            histo_yield_up = cast(List[float], histogram_up.yields.tolist())
+            histo_yield_down = cast(List[float], histogram_down.yields.tolist())
 
         log.debug(
             f"normalization impact of systematic {systematic['Name']} on sample "
@@ -508,9 +509,12 @@ def _symmetrized_templates_and_norm(
     # normalize the variation to the same yield as nominal
     norm_effect_var = variation.normalize_to_yield(reference)
     norm_effect_sym = 2 - norm_effect_var
-    histo_yield_var = variation.yields.tolist()
+    # manually cast due to https://github.com/numpy/numpy/issues/27944
+    histo_yield_var = cast(List[float], variation.yields.tolist())
     # need another histogram that corresponds to the symmetrized variation,
     # which is 2*nominal - variation
-    histo_yield_sym = (2 * reference.yields - variation.yields).tolist()
+    histo_yield_sym = cast(
+        List[float], (2 * reference.yields - variation.yields).tolist()
+    )
 
     return histo_yield_var, histo_yield_sym, norm_effect_var, norm_effect_sym


### PR DESCRIPTION
#498 temporarily removed `mypy` from pre-commit, this adds it back. The changes required are related to typing changes in `numpy` v2.2.

The incompatible types problem in the `.tolist()` context seem to originate from a bug in `mypy` as discussed in https://github.com/numpy/numpy/issues/27944. `numpy` recommends [`basedpyright`](https://github.com/DetachHead/basedpyright) in the [2.2.1 release notes](https://github.com/numpy/numpy/releases/tag/v2.2.1), a potential consideration for the future.

```
* enable mypy in pre-commit tests again
* manually type cast to avoid mypy bugs with .tolist() calls in numpy
* updated pre-commit
```