### PR TITLE
fix: truncate labels on data/MC plots per line

### DIFF
--- a/src/cabinetry/visualize/plot_model.py
+++ b/src/cabinetry/visualize/plot_model.py
@@ -222,8 +222,11 @@ def data_mc(
         ax2.set_xscale("log")
 
     # figure label (region name)
+    label = "\n".join(
+        [f"{line[:30]}..." if len(line) > 30 else line for line in label.split("\n")]
+    )
     at = mpl.offsetbox.AnchoredText(
-        f"{label[:30]}..." if len(label) > 30 else label,
+        label,
         loc="upper left",
         frameon=False,
         prop={"fontsize": "large", "linespacing": 1.5},

--- a/src/cabinetry/visualize/plot_model.py
+++ b/src/cabinetry/visualize/plot_model.py
@@ -221,7 +221,7 @@ def data_mc(
         ax1.set_xscale("log")
         ax2.set_xscale("log")
 
-    # figure label (region name)
+    # figure label (region name and prediction label, truncate per line)
     label = "\n".join(
         [f"{line[:30]}..." if len(line) > 30 else line for line in label.split("\n")]
     )


### PR DESCRIPTION
#496 added functionality to truncate long label names, but the prediction label (e.g. "pre-fit") was part of the same string and also got truncated. This fixes the behavior to truncate per line.

```
* truncate channel name and prediction label per line on data/MC plots
```