### PR TITLE
feat: allow merging of samples for displaying model predictions

### DIFF
--- a/src/cabinetry/model_utils.py
+++ b/src/cabinetry/model_utils.py
@@ -422,11 +422,7 @@ def yield_stdev(
     """
     light_model = LightModel(model, samples_merge_map)
     # check whether results are already stored in cache
-    samples_string = (
-        ",".join(light_model.config.samples)
-        if samples_merge_map is not None
-        else ",".join(model.config.samples)
-    )
+    samples_string = ",".join(light_model.config.samples)
     cached_results = _YIELD_STDEV_CACHE.get(
         (
             _hashable_model_key(model),

--- a/src/cabinetry/model_utils.py
+++ b/src/cabinetry/model_utils.py
@@ -108,6 +108,13 @@ def _merge_sample_yields(
     samples_merge_map = model.config.samples_merge_map
 
     def _sum_per_channel(i_ch: Optional[int] = None) -> np.ndarray:
+        # mypy not able to tell that map cannot be None-typed
+        # so we have to check
+        if samples_merge_map is None:
+            raise ValueError(
+                "Something has gone wrong in merging samples."
+                + " Report this to the dev team."
+            )
         # explicit type casting because mypy worries that old_yield
         # will be list(list(float)) or list(float)
         # but this will never happen because of the if condition
@@ -123,20 +130,14 @@ def _merge_sample_yields(
         remaining_samples: np.ndarray = np.delete(
             old_yield, model.config.merged_samples_indices, axis=0
         )
-        # mypy not able to tell that map cannot be None-typed
-        # so we have to check
-        if samples_merge_map is not None:
-            model_yields_one_channel = np.insert(
-                remaining_samples,
-                np.arange(len(samples_merge_map.keys())),
-                summed_sample,
-                axis=0,
-            )
-        else:
-            log.critical(
-                "Something has gone wrong in merging samples."
-                + " Report this to the dev team."
-            )
+
+        model_yields_one_channel = np.insert(
+            remaining_samples,
+            np.arange(len(samples_merge_map.keys())),
+            summed_sample,
+            axis=0,
+        )
+
         return model_yields_one_channel
 
     new_yields = []

--- a/src/cabinetry/model_utils.py
+++ b/src/cabinetry/model_utils.py
@@ -370,11 +370,13 @@ def yield_stdev(
     of this function are cached to speed up subsequent calls with the same arguments.
 
     Args:
-        model (LightModel): the model for which to calculate the standard deviations
+        model (pyhf.pdf.Model): the model for which to calculate the standard deviations
             for all bins
         parameters (np.ndarray): central values of model parameters
         uncertainty (np.ndarray): uncertainty of model parameters
         corr_mat (np.ndarray): correlation matrix
+        light_model (Optional[LightModel], optional): light-weight model to use for
+            merging samples, defaults to None
 
     Returns:
         Tuple[List[List[List[float]]], List[List[float]]]:

--- a/src/cabinetry/model_utils.py
+++ b/src/cabinetry/model_utils.py
@@ -155,8 +155,8 @@ class ModelPrediction(NamedTuple):
     """Model prediction with yields and total uncertainties per bin and channel.
 
     Args:
-        model (LightModel): model (a light-weight version of pyhf.pdf.Model) to
-            which prediction corresponds to
+        model (LightModel or pyhf.pdf.Model): model (or a light-weight version of
+            pyhf.pdf.Model) to which prediction corresponds to
         model_yields (List[List[List[float]]]): yields per channel, sample and bin,
             indices: channel, sample, bin
         total_stdev_model_bins (List[List[List[float]]]): total yield uncertainty per
@@ -167,7 +167,7 @@ class ModelPrediction(NamedTuple):
         label (str): label for the prediction, e.g. "pre-fit" or "post-fit"
     """
 
-    model: pyhf.pdf.Model
+    model: Union[LightModel, pyhf.pdf.Model]
     model_yields: List[List[List[float]]]
     total_stdev_model_bins: List[List[List[float]]]
     total_stdev_model_channels: List[List[float]]
@@ -635,7 +635,11 @@ def prediction(
     )
 
     return ModelPrediction(
-        model, model_yields, total_stdev_model_bins, total_stdev_model_channels, label
+        light_model,
+        model_yields,
+        total_stdev_model_bins,
+        total_stdev_model_channels,
+        label,
     )
 
 
@@ -728,11 +732,11 @@ def _poi_index(
     return poi_index
 
 
-def _strip_auxdata(model: pyhf.pdf.Model, data: List[float]) -> List[float]:
+def _strip_auxdata(model: LightModel, data: List[float]) -> List[float]:
     """Always returns observed yields, no matter whether data includes auxdata.
 
     Args:
-        model (pyhf.pdf.Model): model to which data corresponds to
+        model (LightModel): model to which data corresponds to
         data (List[float]): data, either including auxdata which is then stripped off or
             only observed yields
 
@@ -746,11 +750,11 @@ def _strip_auxdata(model: pyhf.pdf.Model, data: List[float]) -> List[float]:
     return data
 
 
-def _data_per_channel(model: pyhf.pdf.Model, data: List[float]) -> List[List[float]]:
+def _data_per_channel(model: LightModel, data: List[float]) -> List[List[float]]:
     """Returns data split per channel, and strips off auxiliary data if included.
 
     Args:
-        model (pyhf.pdf.Model): model to which data corresponds to
+        model (LightModel): model to which data corresponds to
         data (List[float]): data (not split by channel), can either include auxdata
             which is then stripped off, or only observed yields
 
@@ -768,12 +772,12 @@ def _data_per_channel(model: pyhf.pdf.Model, data: List[float]) -> List[List[flo
 
 
 def _filter_channels(
-    model: pyhf.pdf.Model, channels: Optional[Union[str, List[str]]]
+    model: LightModel, channels: Optional[Union[str, List[str]]]
 ) -> List[str]:
     """Returns a list of channels in a model after applying filtering.
 
     Args:
-        model (pyhf.pdf.Model): model from which to extract channels
+        model (LightModel): model from which to extract channels
         channels (Optional[Union[str, List[str]]]): name of channel or list of channels
             to filter, only including those channels provided via this argument in the
             return of the function

--- a/src/cabinetry/model_utils.py
+++ b/src/cabinetry/model_utils.py
@@ -634,7 +634,11 @@ def prediction(
     # indices: (channel, sample, bin) for per-bin uncertainties,
     # (channel, sample) for per-channel
     total_stdev_model_bins, total_stdev_model_channels = yield_stdev(
-        light_model, param_values, param_uncertainty, corr_mat
+        light_model,
+        param_values,
+        param_uncertainty,
+        corr_mat,
+        samples_merge_map=samples_merge_map,
     )
 
     return ModelPrediction(

--- a/src/cabinetry/model_utils.py
+++ b/src/cabinetry/model_utils.py
@@ -39,26 +39,10 @@ class LightConfig:
         self.channel_slices = model.config.channel_slices
         self.channel_nbins = model.config.channel_nbins
         self.npars = model.config.npars
-        # this is going to break if more config kwargs added in pyhf _ModelConfig
-        self.modifier_settings = model.config.modifier_settings
         self.samples_merge_map = samples_merge_map
         self.merged_samples_indices: np.ndarray = np.zeros(0)
         if samples_merge_map is not None:
             self._update_samples(samples_merge_map)
-
-    @property
-    def samples(self) -> List[str]:
-        """
-        Ordered list of sample names in the model.
-        """
-        return self._samples
-
-    @samples.setter
-    def samples(self, samples: List[str]) -> None:
-        """
-        Set the Ordered list of sample names in the model.
-        """
-        self._samples = samples
 
     def _update_samples(self, samples_merge_map: Dict[str, List[str]]) -> None:
         # Delete samples being merged from config
@@ -155,7 +139,7 @@ class ModelPrediction(NamedTuple):
     """Model prediction with yields and total uncertainties per bin and channel.
 
     Args:
-        model (LightModel or pyhf.pdf.Model): model (or a light-weight version of
+        model Union[LightModel, pyhf.pdf.Model]: model (or a light-weight version of
             pyhf.pdf.Model) to which prediction corresponds to
         model_yields (List[List[List[float]]]): yields per channel, sample and bin,
             indices: channel, sample, bin
@@ -205,7 +189,7 @@ def model_and_data(
 
 
 def asimov_data(
-    model: pyhf.Model,
+    model: pyhf.pdf.Model,
     *,
     fit_results: Optional[FitResults] = None,
     poi_name: Optional[str] = None,
@@ -222,7 +206,7 @@ def asimov_data(
     fitted again.
 
     Args:
-        model (pyhf.Model): the model from which to construct the dataset
+        model (pyhf.pdf.Model): the model from which to construct the dataset
         fit_results (Optional[FitResults], optional): parameter configuration to use
             when building the Asimov dataset (using the best-fit result), defaults to
             None (then a pre-fit Asimov dataset is built)
@@ -740,11 +724,13 @@ def _poi_index(
     return poi_index
 
 
-def _strip_auxdata(model: LightModel, data: List[float]) -> List[float]:
+def _strip_auxdata(
+    model: Union[pyhf.pdf.Model, LightModel], data: List[float]
+) -> List[float]:
     """Always returns observed yields, no matter whether data includes auxdata.
 
     Args:
-        model (LightModel): model to which data corresponds to
+        model (Union[pyhf.pdf.Model, LightModel]): model to which data corresponds to
         data (List[float]): data, either including auxdata which is then stripped off or
             only observed yields
 
@@ -758,11 +744,13 @@ def _strip_auxdata(model: LightModel, data: List[float]) -> List[float]:
     return data
 
 
-def _data_per_channel(model: LightModel, data: List[float]) -> List[List[float]]:
+def _data_per_channel(
+    model: Union[pyhf.pdf.Model, LightModel], data: List[float]
+) -> List[List[float]]:
     """Returns data split per channel, and strips off auxiliary data if included.
 
     Args:
-        model (LightModel): model to which data corresponds to
+        model (Union[pyhf.pdf.Model, LightModel]): model to which data corresponds to
         data (List[float]): data (not split by channel), can either include auxdata
             which is then stripped off, or only observed yields
 
@@ -780,12 +768,12 @@ def _data_per_channel(model: LightModel, data: List[float]) -> List[List[float]]
 
 
 def _filter_channels(
-    model: LightModel, channels: Optional[Union[str, List[str]]]
+    model: Union[pyhf.pdf.Model, LightModel], channels: Optional[Union[str, List[str]]]
 ) -> List[str]:
     """Returns a list of channels in a model after applying filtering.
 
     Args:
-        model (LightModel): model from which to extract channels
+        model (Union[pyhf.pdf.Model, LightModel]): model from which to extract channels
         channels (Optional[Union[str, List[str]]]): name of channel or list of channels
             to filter, only including those channels provided via this argument in the
             return of the function

--- a/src/cabinetry/model_utils.py
+++ b/src/cabinetry/model_utils.py
@@ -34,6 +34,17 @@ class LightConfig:
         model: pyhf.pdf.Model,
         samples_merge_map: Optional[Dict[str, List[str]]] = None,
     ):
+        """
+        Light-weight version of the pyhf model configuration object. This is used to
+        to manipulate elements of the model that affect representations of results,
+        but not the results itself.
+
+        Args:
+            model (pyhf.pdf.Model): pyhf model to base the light model on
+            samples_merge_map (Optional[Dict[str, List[str]]], optional): a map
+                specifying how to merge samples (values) into one sample (key).
+                Defaults to None.
+        """
         self.samples = model.config.samples
         self.channels = model.config.channels
         self.channel_slices = model.config.channel_slices
@@ -45,6 +56,15 @@ class LightConfig:
             self._update_samples(samples_merge_map)
 
     def _update_samples(self, samples_merge_map: Dict[str, List[str]]) -> None:
+        """
+        Updates the samples in the model configuration to reflect the samples that are
+        merged into one sample. The samples that are merged are removed from the
+        configuration, and the new sample is added to the end of the list.
+
+        Args:
+            samples_merge_map (Dict[str, List[str]]): a map specifying how to merge
+                samples (values) into one sample (key).
+        """
         # Delete samples being merged from config
         # Flatten all merged samples into a set for O(1) lookups
         merged_samples_set = {
@@ -79,6 +99,17 @@ class LightModel:
         model: pyhf.pdf.Model,
         samples_merge_map: Optional[Dict[str, List[str]]] = None,
     ):
+        """
+        Light-weight version of the pyhf model object. This is used to
+        to manipulate elements of the model that affect representations of results,
+        but not the results itself.
+
+        Args:
+            model (pyhf.pdf.Model): pyhf model to base the light model on
+            samples_merge_map (Optional[Dict[str, List[str]]], optional): a map
+                specifying how to merge samples (values) into one sample (key).
+                Defaults to None.
+        """
         self.config = LightConfig(model, samples_merge_map)
         self.spec = model.spec
 
@@ -88,6 +119,23 @@ def _merge_sample_yields(
     old_yields: Union[List[List[List[float]]], List[List[float]]],
     one_channel: Optional[bool] = False,
 ) -> np.ndarray:
+    """
+    Merges the yields of samples specified in the samples_merge_map of the model
+    configuration. The samples are merged into one sample, and the yields are summed
+    together. The merged sample is added to the end of the list of samples.
+
+    Args:
+        model (LightModel): LightModel object containing the model configuration
+        old_yields (Union[List[List[List[float]]], List[List[float]]]): yields to be
+            merged, either per channel (list of lists of lists) or for one channel
+            (list of lists)
+        one_channel (Optional[bool], optional): whether the yields are for one channel
+            (True) or for multiple channels (False). Defaults to False.
+
+    Returns:
+        np.ndarray: merged yields, either per channel (list of lists of lists) or for
+            one channel (list of lists)
+    """
 
     samples_merge_map = model.config.samples_merge_map
 

--- a/src/cabinetry/model_utils.py
+++ b/src/cabinetry/model_utils.py
@@ -28,11 +28,73 @@ log = logging.getLogger(__name__)
 _YIELD_STDEV_CACHE: Dict[Any, Tuple[List[List[List[float]]], List[List[float]]]] = {}
 
 
+class LightConfig(pyhf.pdf._ModelConfig):
+    def __init__(
+        self,
+        model: pyhf.pdf.Model,
+        samples_merge_map: Optional[Dict[str, List[str]]] = None,
+    ):
+        super().__init__(model.spec)
+        # self.channel_nbins = model.config.channel_nbins
+        # self.channels = model.config.channels
+        # self.channel_slices = model.config.channel_slices
+        # self.pyhf_model = model # Can this get too big and become a memory issue ?
+        # self.samples = model.config.samples
+        if samples_merge_map is not None:
+            self._update_samples(samples_merge_map)
+
+    @property
+    def samples(self) -> list[str]:
+        """
+        Ordered list of sample names in the model.
+        """
+        return self._samples
+
+    @samples.setter
+    def samples(self, samples):
+        """
+        Set the Ordered list of sample names in the model.
+        """
+        self._samples = samples
+
+    def _update_samples(self, samples_merge_map: Optional[Dict[str, List[str]]]):
+        # Delete samples being merged from config
+        # Flatten all merged samples into a set for O(1) lookups
+        merged_samples_set = {
+            merged_sample
+            for merged_samples_list in samples_merge_map.values()
+            for merged_sample in merged_samples_list
+        }
+        merged_samples_idxs = [
+            idx
+            for idx, sample in enumerate(self.samples)
+            if sample in merged_samples_set
+        ]
+        self.samples = np.delete(self.samples, merged_samples_idxs).tolist()
+        # Add new samples at the bottom of stack
+        self.samples = np.insert(
+            np.array(self.samples, dtype=object),
+            np.arange(len(samples_merge_map)),
+            list(samples_merge_map.keys()),
+            axis=0,
+        ).tolist()
+
+
+class LightModel:
+    def __init__(
+        self,
+        model: pyhf.pdf.Model,
+        samples_merge_map: Optional[Dict[str, List[str]]] = None,
+    ):
+        self.config = LightConfig(model, samples_merge_map)
+
+
 class ModelPrediction(NamedTuple):
     """Model prediction with yields and total uncertainties per bin and channel.
 
     Args:
-        model (pyhf.pdf.Model): model to which prediction corresponds to
+        model (LightModel): model (a light-weight version of pyhf.pdf.Model) to
+            which prediction corresponds to
         model_yields (List[List[List[float]]]): yields per channel, sample and bin,
             indices: channel, sample, bin
         total_stdev_model_bins (List[List[List[float]]]): total yield uncertainty per
@@ -430,6 +492,7 @@ def prediction(
     *,
     fit_results: Optional[FitResults] = None,
     label: Optional[str] = None,
+    samples_merge_map: Optional[Dict[str, List[str]]] = None,
 ) -> ModelPrediction:
     """Returns model prediction, including model yields and uncertainties.
 
@@ -450,6 +513,8 @@ def prediction(
     Returns:
         ModelPrediction: model, yields and uncertainties per channel, sample, bin
     """
+    light_model = LightModel(model, samples_merge_map)
+    log.debug(light_model.config.samples)
     if fit_results is not None:
         if fit_results.labels != model.config.par_names:
             log.warning("parameter names in fit results and model do not match")

--- a/src/cabinetry/model_utils.py
+++ b/src/cabinetry/model_utils.py
@@ -628,7 +628,7 @@ def prediction(
     if samples_merge_map is not None:
         model_yields = _merge_sample_yields(
             light_model, model_yields, samples_merge_map
-        )
+        ).tolist()
 
     # calculate the total standard deviation of the model prediction
     # indices: (channel, sample, bin) for per-bin uncertainties,

--- a/src/cabinetry/model_utils.py
+++ b/src/cabinetry/model_utils.py
@@ -393,6 +393,7 @@ def yield_stdev(
             tuple(parameters),
             tuple(uncertainty),
             corr_mat.data.tobytes(),
+            ",".join(model.config.samples),
         ),
         None,
     )
@@ -490,7 +491,6 @@ def yield_stdev(
     # convert to numpy arrays for further processing
     up_variations_np = np.asarray(up_variations)
     down_variations_np = np.asarray(down_variations)
-
     # calculate symmetric uncertainties for all components
     # indices: variation, channel (last entries sums), sample (last entry sum), bin
     sym_uncs = (up_variations_np - down_variations_np) / 2
@@ -554,6 +554,7 @@ def yield_stdev(
                 tuple(parameters),
                 tuple(uncertainty),
                 corr_mat.data.tobytes(),
+                ",".join(model.config.samples),
             ): (total_stdev_per_bin, total_stdev_per_channel)
         }
     )
@@ -588,7 +589,6 @@ def prediction(
         ModelPrediction: model, yields and uncertainties per channel, sample, bin
     """
     light_model = LightModel(model, samples_merge_map)
-    log.debug(light_model.config.samples)
     if fit_results is not None:
         if fit_results.labels != model.config.par_names:
             log.warning("parameter names in fit results and model do not match")

--- a/src/cabinetry/model_utils.py
+++ b/src/cabinetry/model_utils.py
@@ -44,7 +44,7 @@ class LightConfig(pyhf.pdf._ModelConfig):
             self._update_samples(samples_merge_map)
 
     @property
-    def samples(self) -> list[str]:
+    def samples(self) -> List[str]:
         """
         Ordered list of sample names in the model.
         """

--- a/src/cabinetry/model_utils.py
+++ b/src/cabinetry/model_utils.py
@@ -47,18 +47,6 @@ class LightConfig:
         if samples_merge_map is not None:
             self._update_samples(samples_merge_map)
 
-    # def __getattr__(self, name):
-    #     """
-    #     Dynamically forward attribute access to the original config if not found.
-    #     """
-    #     try:
-    #         print("name from config: ", name)
-    #         return getattr(self._original_config, name)
-    #     except AttributeError as e:
-    #         raise AttributeError(
-    #             f"'LightConfig' object has no attribute '{name}'"
-    #         ) from e
-
     @property
     def samples(self) -> List[str]:
         """
@@ -105,18 +93,6 @@ class LightModel:
     ):
         self.config = LightConfig(model, samples_merge_map)
         self.spec = model.spec
-
-    # def __getattr__(self, name):
-    #     """
-    #     Dynamically forward attribute access to the original model if not found.
-    #     """
-    #     try:
-    #         print("name from model: ", name)
-    #         return getattr(self._pyhf_model, name)
-    #     except AttributeError as e:
-    #         raise AttributeError(
-    #             f"'LightModel' object has no attribute '{name}'"
-    #         ) from e
 
 
 def _merge_sample_yields(

--- a/src/cabinetry/model_utils.py
+++ b/src/cabinetry/model_utils.py
@@ -29,15 +29,17 @@ _YIELD_STDEV_CACHE: Dict[Any, Tuple[List[List[List[float]]], List[List[float]]]]
 
 
 class LightConfig:
+    """Light-weight version of the pyhf model configuration object."""
+
     def __init__(
         self,
         model: pyhf.pdf.Model,
         samples_merge_map: Optional[Dict[str, List[str]]] = None,
     ):
-        """
-        Light-weight version of the pyhf model configuration object. This is used to
-        to manipulate elements of the model that affect representations of results,
-        but not the results itself.
+        """Creates an instance of the light-weight model configuration object.
+
+        This is used to to manipulate elements of the model that affect representations
+        of results, but not the results itself.
 
         Args:
             model (pyhf.pdf.Model): pyhf model to base the light model on
@@ -56,10 +58,7 @@ class LightConfig:
             self._update_samples(samples_merge_map)
 
     def _update_samples(self, samples_merge_map: Dict[str, List[str]]) -> None:
-        """
-        Updates the samples in the model configuration to reflect the samples that are
-        merged into one sample. The samples that are merged are removed from the
-        configuration, and the new sample is added to the end of the list.
+        """Updates samples list after merging samples into one.
 
         Args:
             samples_merge_map (Dict[str, List[str]]): a map specifying how to merge
@@ -94,15 +93,17 @@ class LightConfig:
 
 
 class LightModel:
+    """Light-weight version of the pyhf model object."""
+
     def __init__(
         self,
         model: pyhf.pdf.Model,
         samples_merge_map: Optional[Dict[str, List[str]]] = None,
     ):
-        """
-        Light-weight version of the pyhf model object. This is used to
-        to manipulate elements of the model that affect representations of results,
-        but not the results itself.
+        """Create an instance of the light-weight model object.
+
+        This is used to to manipulate elements of the model that affect
+        representations of results, but not the results itself.
 
         Args:
             model (pyhf.pdf.Model): pyhf model to base the light model on
@@ -119,10 +120,9 @@ def _merge_sample_yields(
     old_yields: Union[List[List[List[float]]], List[List[float]]],
     one_channel: Optional[bool] = False,
 ) -> np.ndarray:
-    """
-    Merges the yields of samples specified in the samples_merge_map of the model
-    configuration. The samples are merged into one sample, and the yields are summed
-    together. The merged sample is added to the end of the list of samples.
+    """Merges the yields of samples specified in the samples_merge_map.
+
+    The merged sample is added to the end of the list of samples.
 
     Args:
         model (LightModel): LightModel object containing the model configuration

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -235,7 +235,7 @@ def example_spec_with_background():
 
 
 @pytest.fixture
-def example_spec_with_multiple_background():
+def example_spec_with_multiple_backgrounds():
     spec = {
         "channels": [
             {

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -235,6 +235,76 @@ def example_spec_with_background():
 
 
 @pytest.fixture
+def example_spec_with_multiple_background():
+    spec = {
+        "channels": [
+            {
+                "name": "Signal Region",
+                "samples": [
+                    {
+                        "data": [50],
+                        "modifiers": [
+                            {
+                                "data": [5],
+                                "name": "staterror_Signal-Region",
+                                "type": "staterror",
+                            },
+                            {
+                                "data": None,
+                                "name": "Signal strength",
+                                "type": "normfactor",
+                            },
+                        ],
+                        "name": "Signal",
+                    },
+                    {
+                        "data": [150],
+                        "modifiers": [
+                            {
+                                "data": [7],
+                                "name": "staterror_Signal-Region",
+                                "type": "staterror",
+                            }
+                        ],
+                        "name": "Background",
+                    },
+                    {
+                        "data": [20],
+                        "modifiers": [
+                            {
+                                "data": [1],
+                                "name": "staterror_Signal-Region",
+                                "type": "staterror",
+                            },
+                            {
+                                "data": None,
+                                "name": "Background 2 norm",
+                                "type": "normfactor",
+                            },
+                        ],
+                        "name": "Background 2",
+                    },
+                ],
+            }
+        ],
+        "measurements": [
+            {
+                "config": {
+                    "parameters": [
+                        {"name": "Signal strength", "bounds": [[0, 10]], "inits": [1.0]}
+                    ],
+                    "poi": "Signal strength",
+                },
+                "name": "signal plus background",
+            }
+        ],
+        "observations": [{"data": [160], "name": "Signal Region"}],
+        "version": "1.0.0",
+    }
+    return spec
+
+
+@pytest.fixture
 def example_spec_no_aux():
     spec = {
         "channels": [

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -54,12 +54,7 @@ def test_backend_integration(backend, reset_backend):
     param_uncertainty = cabinetry.model_utils.prefit_uncertainties(model)
     corr_mat = np.zeros(shape=(len(param_values), len(param_values)))
     np.fill_diagonal(corr_mat, 1.0)
-    cabinetry.model_utils.yield_stdev(
-        model,
-        param_values,
-        param_uncertainty,
-        corr_mat,
-    )
+    cabinetry.model_utils.yield_stdev(model, param_values, param_uncertainty, corr_mat)
 
 
 def test_backend_reset():

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -55,7 +55,7 @@ def test_backend_integration(backend, reset_backend):
     corr_mat = np.zeros(shape=(len(param_values), len(param_values)))
     np.fill_diagonal(corr_mat, 1.0)
     cabinetry.model_utils.yield_stdev(
-        cabinetry.model_utils.LightModel(model),
+        model,
         param_values,
         param_uncertainty,
         corr_mat,

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -54,7 +54,12 @@ def test_backend_integration(backend, reset_backend):
     param_uncertainty = cabinetry.model_utils.prefit_uncertainties(model)
     corr_mat = np.zeros(shape=(len(param_values), len(param_values)))
     np.fill_diagonal(corr_mat, 1.0)
-    cabinetry.model_utils.yield_stdev(model, param_values, param_uncertainty, corr_mat)
+    cabinetry.model_utils.yield_stdev(
+        cabinetry.model_utils.LightModel(model),
+        param_values,
+        param_uncertainty,
+        corr_mat,
+    )
 
 
 def test_backend_reset():

--- a/tests/test_model_utils.py
+++ b/tests/test_model_utils.py
@@ -71,6 +71,34 @@ def test_LightModel(example_spec_with_multiple_background):
         model_pred.model.NonExistent
 
 
+def test__merge_sample_yields(example_spec_with_multiple_background):
+    model = pyhf.Workspace(example_spec_with_multiple_background).model()
+    samples_merge_map = {"Total Background": ["Background", "Background 2"]}
+    light_model = model_utils.LightModel(model, samples_merge_map)
+    # per-channel
+    yields = [[10.0], [20.0], [30.0]]
+    merged_yields = model_utils._merge_sample_yields(
+        light_model, yields, one_channel=True
+    )
+    assert np.allclose(merged_yields, [[30.0], [30.0]])
+    # per-bin
+    yields = [[[10.0], [20.0], [30.0]]]
+    merged_yields = model_utils._merge_sample_yields(
+        light_model, yields, one_channel=False
+    )
+    assert np.allclose(merged_yields, [[[30.0], [30.0]]])
+
+    light_model = model_utils.LightModel(model, None)
+    with pytest.raises(
+        ValueError,
+        match="Something has gone wrong in merging samples."
+        + " Report this to the dev team.",
+    ):
+        merged_yields = model_utils._merge_sample_yields(
+            light_model, yields, one_channel=False
+        )
+
+
 def test_ModelPrediction(example_spec):
     model = pyhf.Workspace(example_spec).model()
     model_yields = [[[10.0]]]

--- a/tests/test_model_utils.py
+++ b/tests/test_model_utils.py
@@ -21,7 +21,7 @@ def test_LightModel(example_spec_with_multiple_backgrounds):
         0.0,
     )
     model_pred = model_utils.prediction(
-        model, fit_results=fit_results, samples_merge_map=None
+        model, fit_results=fit_results, sample_update_map=None
     )
 
     assert model_pred.model.config.samples == ["Background", "Background 2", "Signal"]
@@ -41,7 +41,7 @@ def test_LightModel(example_spec_with_multiple_backgrounds):
     model_pred = model_utils.prediction(
         model,
         fit_results=fit_results,
-        samples_merge_map={"Total Background": ["Background", "Background 2"]},
+        sample_update_map={"Total Background": ["Background", "Background 2"]},
     )
 
     assert model_pred.model.config.samples == ["Total Background", "Signal"]
@@ -71,8 +71,8 @@ def test_LightModel(example_spec_with_multiple_backgrounds):
 
 def test__merge_sample_yields(example_spec_with_multiple_backgrounds):
     model = pyhf.Workspace(example_spec_with_multiple_backgrounds).model()
-    samples_merge_map = {"Total Background": ["Background", "Background 2"]}
-    light_model = model_utils.LightModel(model, samples_merge_map)
+    sample_update_map = {"Total Background": ["Background", "Background 2"]}
+    light_model = model_utils.LightModel(model, sample_update_map)
     # per-channel
     yields = [[10.0], [20.0], [30.0]]
     merged_yields = model_utils._merge_sample_yields(
@@ -345,7 +345,7 @@ def test_yield_stdev(
         assert np.allclose(from_cache[1][i_reg], expected_stdev_chan[i_reg])
 
     # Multiple backgrounds with sample merging
-    samples_merge_map = {"Total Background": ["Background", "Background 2"]}
+    sample_update_map = {"Total Background": ["Background", "Background 2"]}
     # post-fit
     model = pyhf.Workspace(example_spec_with_multiple_backgrounds).model()
     parameters = np.asarray([1.1, 1.01, 1.2])
@@ -357,7 +357,7 @@ def test_yield_stdev(
         parameters,
         uncertainty,
         corr_mat,
-        samples_merge_map=samples_merge_map,
+        sample_update_map=sample_update_map,
     )
     assert np.allclose(
         total_stdev_bin,
@@ -376,7 +376,7 @@ def test_yield_stdev(
         parameters,
         uncertainty,
         diag_corr_mat,
-        samples_merge_map=samples_merge_map,
+        sample_update_map=sample_update_map,
     )
     assert np.allclose(
         total_stdev_bin,
@@ -459,7 +459,7 @@ def test_prediction(
     assert np.allclose(
         mock_stdev.call_args_list[0][0][3], np.diagflat([1.0, 1.0, 1.0, 1.0])
     )
-    assert mock_stdev.call_args_list[0][1] == {"samples_merge_map": None}
+    assert mock_stdev.call_args_list[0][1] == {"sample_update_map": None}
 
     # post-fit prediction, single-channel model
     model = pyhf.Workspace(example_spec).model()
@@ -492,7 +492,7 @@ def test_prediction(
     assert np.allclose(
         mock_stdev.call_args_list[1][0][3], np.asarray([[1.0, 0.2], [0.2, 1.0]])
     )
-    assert mock_stdev.call_args_list[1][1] == {"samples_merge_map": None}
+    assert mock_stdev.call_args_list[1][1] == {"sample_update_map": None}
 
     caplog.clear()
 
@@ -512,10 +512,10 @@ def test_prediction(
     caplog.clear()
 
     # Multiple backgrounds with sample merging
-    samples_merge_map = {"Total Background": ["Background", "Background 2"]}
+    sample_update_map = {"Total Background": ["Background", "Background 2"]}
     model = pyhf.Workspace(example_spec_with_multiple_backgrounds).model()
     # pre-fit prediction, merged samples
-    model_pred = model_utils.prediction(model, samples_merge_map=samples_merge_map)
+    model_pred = model_utils.prediction(model, sample_update_map=sample_update_map)
     assert len(model_pred.model.config.samples) == len(model.config.samples) - 1
     assert model_pred.model.spec == model.spec
     # yields from pyhf expected_data call, per-bin / per-channel uncertainty from mock
@@ -533,7 +533,7 @@ def test_prediction(
 
     # call to stdev calculation
     assert mock_stdev.call_count == 4
-    assert mock_stdev.call_args_list[3][1] == {"samples_merge_map": samples_merge_map}
+    assert mock_stdev.call_args_list[3][1] == {"sample_update_map": sample_update_map}
 
     # post-fit
     fit_results = FitResults(
@@ -546,7 +546,7 @@ def test_prediction(
     model_pred = model_utils.prediction(
         model,
         fit_results=fit_results,
-        samples_merge_map={"Total Background": ["Background", "Background 2"]},
+        sample_update_map={"Total Background": ["Background", "Background 2"]},
     )
     assert len(model_pred.model.config.samples) == len(model.config.samples) - 1
     assert model_pred.model.spec == model.spec
@@ -565,7 +565,7 @@ def test_prediction(
     # call to stdev calculation
     assert mock_stdev.call_count == 5
     assert mock_stdev.call_args_list[4][1] == {
-        "samples_merge_map": {"Total Background": ["Background", "Background 2"]}
+        "sample_update_map": {"Total Background": ["Background", "Background 2"]}
     }
 
     caplog.clear()

--- a/tests/test_model_utils.py
+++ b/tests/test_model_utils.py
@@ -171,26 +171,31 @@ def test_prefit_uncertainties(
 
 def test__hashable_model_key(example_spec):
     # key matches for two models built from the same spec
-    model_1 = pyhf.Workspace(example_spec).model()
-    model_2 = pyhf.Workspace(example_spec).model()
+    model_1 = model_utils.LightModel(pyhf.Workspace(example_spec).model())
+    model_2 = model_utils.LightModel(pyhf.Workspace(example_spec).model())
     assert model_utils._hashable_model_key(model_1) == model_utils._hashable_model_key(
         model_2
     )
 
     # key does not match if model has different interpcode
-    model_new_interpcode = pyhf.Workspace(example_spec).model(
-        modifier_settings={
-            "normsys": {"interpcode": "code1"},
-            "histosys": {"interpcode": "code0"},
-        }
+    model_new_interpcode = model_utils.LightModel(
+        pyhf.Workspace(example_spec).model(
+            modifier_settings={
+                "normsys": {"interpcode": "code1"},
+                "histosys": {"interpcode": "code0"},
+            }
+        )
     )
+
     assert model_utils._hashable_model_key(model_1) != model_utils._hashable_model_key(
         model_new_interpcode
     )
 
 
-def test_yield_stdev(example_spec, example_spec_multibin):
-    model = pyhf.Workspace(example_spec).model()
+def test_yield_stdev(
+    example_spec, example_spec_multibin, example_spec_with_multiple_background
+):
+    model = model_utils.LightModel(pyhf.Workspace(example_spec).model())
     parameters = np.asarray([0.95, 1.05])
     uncertainty = np.asarray([0.1, 0.1])
     corr_mat = np.asarray([[1.0, 0.2], [0.2, 1.0]])
@@ -212,7 +217,7 @@ def test_yield_stdev(example_spec, example_spec_multibin):
     assert np.allclose(total_stdev_chan, [[2.56754823, 2.56754823]])
 
     # multiple channels, bins, staterrors
-    model = pyhf.Workspace(example_spec_multibin).model()
+    model = model_utils.LightModel(pyhf.Workspace(example_spec_multibin).model())
     parameters = np.asarray([1.3, 0.9, 1.05, 0.95])
     uncertainty = np.asarray([0.3, 0.1, 0.05, 0.1])
     corr_mat = np.asarray(
@@ -252,6 +257,54 @@ def test_yield_stdev(example_spec, example_spec_multibin):
     for i_reg in range(2):
         assert np.allclose(from_cache[0][i_reg], expected_stdev_bin[i_reg])
         assert np.allclose(from_cache[1][i_reg], expected_stdev_chan[i_reg])
+
+    # Multiple backgrounds with sample merging
+    # post-fit
+    model = model_utils.LightModel(
+        pyhf.Workspace(example_spec_with_multiple_background).model(),
+        samples_merge_map={"Total Background": ["Background", "Background 2"]},
+    )
+    """
+    fit_results = FitResults(
+        np.asarray([1.1, 1.01, 1.2]),
+        np.asarray([0.1, 0.03, 0.07]),
+        ["Signal strength", "staterror_Signal-Region[0]", "Background 2 norm"],
+        np.asarray([[1.0, 0.2, 0.1], [0.2, 1.0, 0.3], [0.1, 0.3, 1.0]]),
+        0.0,
+    )
+    model_pred = model_utils.prediction(
+        model,
+        fit_results=fit_results,
+        samples_merge_map={"Total Background": ["Background", "Background 2"]},
+    )
+    """
+    parameters = np.asarray([1.1, 1.01, 1.2])
+    uncertainty = np.asarray([0.1, 0.03, 0.07])
+    corr_mat = np.asarray([[1.0, 0.2, 0.1], [0.2, 1.0, 0.3], [0.1, 0.3, 1.0]])
+
+    total_stdev_bin, total_stdev_chan = model_utils.yield_stdev(
+        model,
+        parameters,
+        uncertainty,
+        corr_mat,
+        samples_merge_map={"Total Background": ["Background", "Background 2"]},
+    )
+    # assert np.allclose(total_stdev_bin, [[[xx], [xx]]])
+    # assert np.allclose(total_stdev_chan, [[xx, xx]])
+
+    # pre-fit
+    parameters = np.asarray([1.0, 1.0, 1.0])
+    uncertainty = np.asarray([0.0, 0.0495665682, 0.01])
+    diag_corr_mat = np.diagflat([1.0, 1.0, 1.0])
+    total_stdev_bin, total_stdev_chan = model_utils.yield_stdev(
+        model,
+        parameters,
+        uncertainty,
+        diag_corr_mat,
+        samples_merge_map={"Total Background": ["Background", "Background 2"]},
+    )
+    # assert np.allclose(total_stdev_bin, [[[xx], [xx]]])  # the staterror
+    # assert np.allclose(total_stdev_chan, [[xx, xx]])
 
 
 @mock.patch(
@@ -310,7 +363,7 @@ def test_prediction(
 
     # call to stdev calculation
     assert mock_stdev.call_count == 1
-    assert mock_stdev.call_args_list[0][0][0] == model
+    assert mock_stdev.call_args_list[0][0][0].pyhf_model == model
     assert np.allclose(mock_stdev.call_args_list[0][0][1], [1.0, 1.0, 1.0, 1.0])
     assert np.allclose(mock_stdev.call_args_list[0][0][2], [0.0, 0.2, 0.4, 0.125])
     assert np.allclose(
@@ -342,7 +395,7 @@ def test_prediction(
 
     # call to stdev calculation with fit_results propagated
     assert mock_stdev.call_count == 2
-    assert mock_stdev.call_args_list[1][0][0] == model
+    assert mock_stdev.call_args_list[1][0][0].pyhf_model == model
     assert np.allclose(mock_stdev.call_args_list[1][0][1], [1.1, 1.01])
     assert np.allclose(mock_stdev.call_args_list[1][0][2], [0.1, 0.03])
     assert np.allclose(

--- a/tests/test_model_utils.py
+++ b/tests/test_model_utils.py
@@ -35,7 +35,6 @@ def test_LightModel(example_spec_with_multiple_background):
     assert model_pred.model.config.channels == model.config.channels
     assert model_pred.model.config.channel_nbins == model.config.channel_nbins
     assert model_pred.model.config.channel_slices == model.config.channel_slices
-    assert model_pred.model.config.modifier_settings == model.config.modifier_settings
     assert model_pred.model.spec == model.spec
 
     # Test with merging samples
@@ -56,7 +55,6 @@ def test_LightModel(example_spec_with_multiple_background):
     assert model_pred.model.config.channels == model.config.channels
     assert model_pred.model.config.channel_nbins == model.config.channel_nbins
     assert model_pred.model.config.channel_slices == model.config.channel_slices
-    assert model_pred.model.config.modifier_settings == model.config.modifier_settings
     assert model_pred.model.spec == model.spec
 
     with pytest.raises(

--- a/tests/test_model_utils.py
+++ b/tests/test_model_utils.py
@@ -10,9 +10,9 @@ from cabinetry import model_utils
 from cabinetry.fit.results_containers import FitResults
 
 
-def test_LightModel(example_spec_with_multiple_background):
+def test_LightModel(example_spec_with_multiple_backgrounds):
     # Test without merging samples
-    model = pyhf.Workspace(example_spec_with_multiple_background).model()
+    model = pyhf.Workspace(example_spec_with_multiple_backgrounds).model()
     fit_results = FitResults(
         np.asarray([1.0, 1.0, 1.0]),
         np.asarray([0.1, 0.03, 0.07]),
@@ -69,8 +69,8 @@ def test_LightModel(example_spec_with_multiple_background):
         model_pred.model.NonExistent
 
 
-def test__merge_sample_yields(example_spec_with_multiple_background):
-    model = pyhf.Workspace(example_spec_with_multiple_background).model()
+def test__merge_sample_yields(example_spec_with_multiple_backgrounds):
+    model = pyhf.Workspace(example_spec_with_multiple_backgrounds).model()
     samples_merge_map = {"Total Background": ["Background", "Background 2"]}
     light_model = model_utils.LightModel(model, samples_merge_map)
     # per-channel
@@ -278,7 +278,7 @@ def test__hashable_model_key(example_spec):
 
 
 def test_yield_stdev(
-    example_spec, example_spec_multibin, example_spec_with_multiple_background
+    example_spec, example_spec_multibin, example_spec_with_multiple_backgrounds
 ):
     model = pyhf.Workspace(example_spec).model()
     parameters = np.asarray([0.95, 1.05])
@@ -347,7 +347,7 @@ def test_yield_stdev(
     # Multiple backgrounds with sample merging
     samples_merge_map = {"Total Background": ["Background", "Background 2"]}
     # post-fit
-    model = pyhf.Workspace(example_spec_with_multiple_background).model()
+    model = pyhf.Workspace(example_spec_with_multiple_backgrounds).model()
     parameters = np.asarray([1.1, 1.01, 1.2])
     uncertainty = np.asarray([0.1, 0.03, 0.07])
     corr_mat = np.asarray([[1.0, 0.2, 0.1], [0.2, 1.0, 0.3], [0.1, 0.3, 1.0]])
@@ -426,7 +426,7 @@ def test_prediction(
     mock_stdev,
     example_spec_multibin,
     example_spec,
-    example_spec_with_multiple_background,
+    example_spec_with_multiple_backgrounds,
     caplog,
 ):
     caplog.set_level(logging.DEBUG)
@@ -513,7 +513,7 @@ def test_prediction(
 
     # Multiple backgrounds with sample merging
     samples_merge_map = {"Total Background": ["Background", "Background 2"]}
-    model = pyhf.Workspace(example_spec_with_multiple_background).model()
+    model = pyhf.Workspace(example_spec_with_multiple_backgrounds).model()
     # pre-fit prediction, merged samples
     model_pred = model_utils.prediction(model, samples_merge_map=samples_merge_map)
     assert len(model_pred.model.config.samples) == len(model.config.samples) - 1

--- a/tests/test_model_utils.py
+++ b/tests/test_model_utils.py
@@ -264,20 +264,6 @@ def test_yield_stdev(
         pyhf.Workspace(example_spec_with_multiple_background).model(),
         samples_merge_map={"Total Background": ["Background", "Background 2"]},
     )
-    """
-    fit_results = FitResults(
-        np.asarray([1.1, 1.01, 1.2]),
-        np.asarray([0.1, 0.03, 0.07]),
-        ["Signal strength", "staterror_Signal-Region[0]", "Background 2 norm"],
-        np.asarray([[1.0, 0.2, 0.1], [0.2, 1.0, 0.3], [0.1, 0.3, 1.0]]),
-        0.0,
-    )
-    model_pred = model_utils.prediction(
-        model,
-        fit_results=fit_results,
-        samples_merge_map={"Total Background": ["Background", "Background 2"]},
-    )
-    """
     parameters = np.asarray([1.1, 1.01, 1.2])
     uncertainty = np.asarray([0.1, 0.03, 0.07])
     corr_mat = np.asarray([[1.0, 0.2, 0.1], [0.2, 1.0, 0.3], [0.1, 0.3, 1.0]])

--- a/tests/test_model_utils.py
+++ b/tests/test_model_utils.py
@@ -264,6 +264,7 @@ def test_yield_stdev(
         pyhf.Workspace(example_spec_with_multiple_background).model(),
         samples_merge_map={"Total Background": ["Background", "Background 2"]},
     )
+
     parameters = np.asarray([1.1, 1.01, 1.2])
     uncertainty = np.asarray([0.1, 0.03, 0.07])
     corr_mat = np.asarray([[1.0, 0.2, 0.1], [0.2, 1.0, 0.3], [0.1, 0.3, 1.0]])
@@ -275,12 +276,17 @@ def test_yield_stdev(
         corr_mat,
         samples_merge_map={"Total Background": ["Background", "Background 2"]},
     )
-    # assert np.allclose(total_stdev_bin, [[[xx], [xx]]])
-    # assert np.allclose(total_stdev_chan, [[xx, xx]])
+    assert np.allclose(
+        total_stdev_bin,
+        [[[12.510027977586642], [4.421993328805458], [16.66150128289767]]],
+    )
+    assert np.allclose(
+        total_stdev_chan, [[12.510027977586642, 4.421993328805458, 16.66150128289767]]
+    )
 
     # pre-fit
     parameters = np.asarray([1.0, 1.0, 1.0])
-    uncertainty = np.asarray([0.0, 0.0495665682, 0.01])
+    uncertainty = np.asarray([0.1, 0.03, 0.07])
     diag_corr_mat = np.diagflat([1.0, 1.0, 1.0])
     total_stdev_bin, total_stdev_chan = model_utils.yield_stdev(
         model,
@@ -289,8 +295,13 @@ def test_yield_stdev(
         diag_corr_mat,
         samples_merge_map={"Total Background": ["Background", "Background 2"]},
     )
-    # assert np.allclose(total_stdev_bin, [[[xx], [xx]]])  # the staterror
-    # assert np.allclose(total_stdev_chan, [[xx, xx]])
+    assert np.allclose(
+        total_stdev_bin,
+        [[[12.066896867049131], [3.8078865529319543], [15.601602481796547]]],
+    )
+    assert np.allclose(
+        total_stdev_chan, [[12.066896867049131, 3.8078865529319543, 15.601602481796547]]
+    )
 
 
 @mock.patch(
@@ -415,8 +426,7 @@ def test_prediction(
     assert model_pred.label == "abc"
     caplog.clear()
 
-    # Test with merging samples
-    # print("\n Testing merged samples \n")
+    # Multiple backgrounds with sample merging
     model = pyhf.Workspace(example_spec_with_multiple_background).model()
     # pre-fit prediction, merged samples
     model_pred = model_utils.prediction(
@@ -447,7 +457,7 @@ def test_prediction(
         np.asarray([1.2, 1.1, 1.01]),
         np.asarray([0.1, 0.07, 0.03]),
         ["Background 2 norm", "Signal strength", "staterror_Signal-Region[0]"],
-        np.asarray([[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]]),
+        np.asarray([[1.0, 0.2, 0.1], [0.2, 1.0, 0.3], [0.1, 0.3, 1.0]]),
         0.0,
     )
     model_pred = model_utils.prediction(

--- a/tests/test_model_utils.py
+++ b/tests/test_model_utils.py
@@ -369,7 +369,7 @@ def test_prediction(
     assert np.allclose(
         mock_stdev.call_args_list[0][0][3], np.diagflat([1.0, 1.0, 1.0, 1.0])
     )
-    assert mock_stdev.call_args_list[0][1] == {}
+    assert mock_stdev.call_args_list[0][1] == {"samples_merge_map": None}
 
     # post-fit prediction, single-channel model
     model = pyhf.Workspace(example_spec).model()
@@ -401,7 +401,7 @@ def test_prediction(
     assert np.allclose(
         mock_stdev.call_args_list[1][0][3], np.asarray([[1.0, 0.2], [0.2, 1.0]])
     )
-    assert mock_stdev.call_args_list[1][1] == {}
+    assert mock_stdev.call_args_list[1][1] == {"samples_merge_map": None}
 
     caplog.clear()
 

--- a/tests/test_model_utils.py
+++ b/tests/test_model_utils.py
@@ -271,7 +271,6 @@ def test__hashable_model_key(example_spec):
             "histosys": {"interpcode": "code0"},
         }
     )
-
     assert model_utils._hashable_model_key(model_1) != model_utils._hashable_model_key(
         model_new_interpcode
     )


### PR DESCRIPTION
A new `sample_update_map` argument to `model_utils.yield_stdev` and `model_utils.prediction` allows merging or renaming samples for presentation in yield tables or data/MC visualizations. Example:
```python
sample_update_map = {"Total Background": ["Background", "Background 2"]}
```
All samples that are not included in the map stay unchanged.

resolves #502

```
* add new sample_update_map argument to model_utils.yield_stdev and model_utils.prediction
* sample_update_map allows merging samples for yield tables and data/MC visualizations
* create lightweight version of pyhf model configuration to propagate information within cabinetry
* allow using LightModel and pyhf model interchangeably where possible within model_utils module
```