### PR TITLE
feat: improve error message when CLs bracketing fails

### DIFF
--- a/src/cabinetry/fit/__init__.py
+++ b/src/cabinetry/fit/__init__.py
@@ -995,8 +995,9 @@ def limit(
         except ValueError:
             # invalid starting bracket is most common issue
             log.error(
-                f"CLs values at {bracket[0]:.4f} and {bracket[1]:.4f} do not bracket "
-                f"CLs={cls_target:.4f}, try a different starting bracket"
+                f"CLs values for {model.config.poi_name}={bracket[0]:.4f} and "
+                f"{bracket[1]:.4f} do not bracket CLs={cls_target:.4f}, try a "
+                "different starting bracket"
             )
             # set POI in model back to original value
             model.config.set_poi(original_model_poi_name)

--- a/tests/fit/test_fit.py
+++ b/tests/fit/test_fit.py
@@ -818,8 +818,8 @@ def test_limit(example_spec_with_background, caplog):
             poi_name="Signal strength",
         )
     assert (
-        "CLs values at 1.0000 and 2.0000 do not bracket CLs=0.1000, try a different "
-        "starting bracket" in [rec.message for rec in caplog.records]
+        "CLs values for Signal strength=1.0000 and 2.0000 do not bracket CLs=0.1000, "
+        "try a different starting bracket" in [rec.message for rec in caplog.records]
     )
     caplog.clear()
 


### PR DESCRIPTION
The old error message did not make it explicit which numbers were POI values, the new version should be a bit more clear.

```
* add POI name to error message to better distinguish between POI and CLs values
```