### PR TITLE
feat: Improve handling of parameter bounds when computing impacts in ranking

### DIFF
--- a/src/cabinetry/fit/__init__.py
+++ b/src/cabinetry/fit/__init__.py
@@ -608,6 +608,10 @@ def ranking(
     init_pars = init_pars or model.config.suggested_init()
     fix_pars = fix_pars or model.config.suggested_fixed()
 
+    par_bounds = par_bounds or [
+        tuple(bound) for bound in model.config.suggested_bounds()
+    ]
+
     all_impacts = []
     for i_par, label in enumerate(labels):
         if i_par == poi_index:
@@ -633,9 +637,6 @@ def ranking(
                 log.debug(f"impact of {label} is zero, skipping fit")
                 parameter_impacts.append(0.0)
             else:
-                par_bounds = par_bounds or [
-                    tuple(bound) for bound in model.config.suggested_bounds()
-                ]
                 if not par_bounds[i_par][0] <= np_val <= par_bounds[i_par][1]:
                     np_val = min(
                         max(np_val, par_bounds[i_par][0]), par_bounds[i_par][1]

--- a/src/cabinetry/fit/__init__.py
+++ b/src/cabinetry/fit/__init__.py
@@ -633,6 +633,13 @@ def ranking(
                 log.debug(f"impact of {label} is zero, skipping fit")
                 parameter_impacts.append(0.0)
             else:
+                par_bounds = par_bounds or [
+                    tuple(bound) for bound in model.config.suggested_bounds()
+                ]
+                if not par_bounds[i_par][0] <= np_val <= par_bounds[i_par][1]:
+                    np_val = min(
+                        max(np_val, par_bounds[i_par][0]), par_bounds[i_par][1]
+                    )
                 init_pars_ranking = init_pars.copy()
                 init_pars_ranking[i_par] = np_val  # value of current nuisance parameter
                 fit_results_ranking = _fit_model(

--- a/tests/fit/test_fit.py
+++ b/tests/fit/test_fit.py
@@ -559,7 +559,9 @@ def test_ranking(mock_fit, example_spec):
             mock_fit.call_args_list[i][1]["init_pars"], expected_inits[i]
         )
         assert np.allclose(mock_fit.call_args_list[i][1]["fix_pars"], expected_fix)
-        assert mock_fit.call_args_list[i][1]["par_bounds"] is None
+        assert np.allclose(
+            mock_fit.call_args_list[i][1]["par_bounds"], model.config.suggested_bounds()
+        )
         assert mock_fit.call_args_list[i][1]["strategy"] is None
         assert mock_fit.call_args_list[i][1]["maxiter"] is None
         assert mock_fit.call_args_list[i][1]["tolerance"] is None


### PR DESCRIPTION
## Summary

When building parameter rankings based on impact, 5 fits must be evaluated for each NP. The fits are evaluated at:
- The best-fit value of the NP
- NP + up uncertainty (pre-fit)
- NP + down uncertainty (pre-fit)
- NP + up uncertainty (post-fit)
- NP + down uncertainty (post-fit)

The uncertainties so far have been extracted from the Hessian. If the bounds of the parameter, which specify valid range of values of this parameter, are not specified by the user, one of the NP values above may step out of the appropriate bound. For example, for a poisson-constrained NP (`shapesys`). If the best-fit value is `1.0` and pre/post-fit uncertainty is `>1`, the NP value will be negative for some of the above fits. Negative parameter values are not allowed in the poisson terms, and hence the corresponding fits fails. 

This can indicate a defective model, or it can be the result of the Hessian uncertainty being symmetrised without respecting parameter bounds. If the user is sure their model is good, some options are added in this PR to help the firs converge:

1- Use suggested bounds from `pyhf` to force the ranking to cap the value of an NP at its physical limit, independently of the uncertainty extracted from the fit. 
2- Use the uncertainty from MINOS on the NP which will respect the parameter boundaries by construction. 

In this MR, an option to the `fit.ranking` function is added to specify that suggested bounds should be used to set limits on the parameters bounds are not set by user. In addition, the ranking function can now read MINOS uncertainties for relevant parameters if the fit results are provided to it. If the fit results are not provided, the ranking function can now perform the fit itself while allowing the use of MINOS for model parameters.
## Example spec

The following spec fails even for pre-fit uncertainties. 

```
spec = {
    "channels": [
        {
            "name": "Signal_region",
            "samples": [
                {
                    "data": [50.0],
                    "modifiers": [
                        {
                            "data": None,
                            "name": "mu",
                            "type": "normfactor"
                        },
                        {
                            "data": [80.0],
                            "name": "test_shapesys",
                            "type": "shapesys"
                        }
                    ],
                    "name": "Signal"
                },
                {
                    "data": [200.0],
                    "modifiers": [],
                    "name": "Background"
                }
            ]
        }
    ],
    "measurements": [
        {
            "config": {
                "parameters": [],
                "poi": "mu"
            },
            "name": "minimal_example"
        }
    ],
    "observations": [
        {
            "data": [250.0],
            "name": "Signal_region"
        }
    ],
    "version": "1.0.0"
```

With this PR the following setups are possible, utilising suggested bounds:
```
model, data = model_utils.model_and_data(spec)
fit_results = fit.fit(model, data, minos=["test_shapesys[0]"])
rank = fit.ranking(model, data, fit_results=fit_results) # fails
rank = fit.ranking(model, data, fit_results=fit_results, par_bounds=[(0,10),(1e-10,10.0)]) # works and already supported
rank = fit.ranking(model, data, fit_results=fit_results, use_suggested_bounds=True) # works and new 
rank = fit.ranking(model, data, fit_results=fit_results, par_bounds=[(0,10),None], use_suggested_bounds=True) # works and 
```

To utilise MINOS, consider the following setup:
```
# We want the fit results to be problematic to check use of minos
bestfit = np.asarray([1.0, 1.0])
uncertainty = np.asarray([0.85, 1.1])
labels = ["POI", "SHAPESYS"]
fit_results = FitResults(bestfit, uncertainty, labels, np.empty(0), 0.0)
fit_results_with_minos = FitResults(bestfit, uncertainty, labels, np.empty(0), 0.0, minos_uncertainty={'test_shapesys[0]': (-0.89, 2.55)})

rank = fit.ranking(model, data, fit_results=fit_results) # fails
rank = fit.ranking(model, data, fit_results=fit_results_with_minos) # works because MINOS is limiting the bounds
```

```
* Added `bool` option for user to specify if suggested bounds should be used for parameters with no user-set bounds
* Ranking now accepts minos arguments when` fit_results` object is not provided
* Ranking now uses post-fit MINOS uncertainties from fit results if they are available for a parameter
```