### PR TITLE
chore: bump python version used for codecov in CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -69,7 +69,7 @@ jobs:
       run: |
         pytest --runslow
     - name: Upload coverage to codecov
-      if: matrix.python-version == '3.8'
+      if: matrix.python-version == '3.9'
       uses: codecov/codecov-action@v4
       with:
         token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -63,7 +63,7 @@ jobs:
         # skip typeguard for coverage https://github.com/agronholm/typeguard/issues/356
         pytest --runslow --cov-report=xml --typeguard-packages=""
     - name: Test with pytest
-      if: matrix.python-version != '3.9'
+      if: matrix.python-version != '3.9' && matrix.python-version != '3.8'
       run: |
         pytest --runslow
     - name: Test with pytest for py38

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -66,6 +66,12 @@ jobs:
       if: matrix.python-version != '3.9'
       run: |
         pytest --runslow
+    - name: Test with pytest for py38
+      if: matrix.python-version == '3.8'
+      run: |
+        # https://github.com/scikit-hep/cabinetry/issues/428
+        pip install --upgrade typing_extensions
+        pytest --runslow
     - name: Upload coverage to codecov
       if: matrix.python-version == '3.9'
       uses: codecov/codecov-action@v4

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -58,14 +58,12 @@ jobs:
     - name: List installed Python packages
       run: python -m pip list
     - name: Test with pytest, generate coverage report (skipping typeguard)
-      if: matrix.python-version == '3.8'
+      if: matrix.python-version == '3.9'
       run: |
-        # https://github.com/scikit-hep/cabinetry/issues/428
-        pip install --upgrade typing_extensions
         # skip typeguard for coverage https://github.com/agronholm/typeguard/issues/356
         pytest --runslow --cov-report=xml --typeguard-packages=""
     - name: Test with pytest
-      if: matrix.python-version != '3.8'
+      if: matrix.python-version != '3.9'
       run: |
         pytest --runslow
     - name: Upload coverage to codecov


### PR DESCRIPTION
In #515  the coverage was observed to be underestimated due to the use of `xfail()` to handle the issue described in #476. This reduced coverage was not observed locally (with `python 3.9.7`). It happens because the CI still uses `python 3.8` to report coverage. This python version will be eventually deprecated, and it makes sense to not use it for code coverage anymore. 

```
* bump python version used to generate code coverage to 3.8
* Run tests for python > 3.9 and python 3.8 separately with no coverage
```