### PR TITLE
ci: Add a GitHub action to handle issue/PR blockers 

### DIFF
--- a/.github/workflows/blocking_issues.yml
+++ b/.github/workflows/blocking_issues.yml
@@ -1,0 +1,20 @@
+name: Blocking Issues and PRs
+
+on:
+  issues:
+    types: [opened, edited, deleted, transferred, closed, reopened]
+  pull_request_target:
+    types: [opened, edited, closed, reopened]
+
+jobs:
+  blocking_issues:
+    runs-on: ubuntu-latest
+    name: Checks for blocking issues
+
+    steps:
+      - uses: Levi-Lesches/blocking-issues@v2
+        with:
+          # Optional: Choose an existing label to use instead of creating a new one.
+          # If the label cannot be found, the default one will be created and used.
+          # The default is: "blocked" (black).
+          use-label: "blocked by another"


### PR DESCRIPTION
This can help with organisation, to automatically detect if a PR should not be merged until another is merged,  or until some issue is resolved. 

Using the following action: https://github.com/Levi-Lesches/blocking-issues

```
* add a GitHub action to test for PR/issue blockers and report them in the PRs/issues
```