### PR TITLE
Implement alternative uncertainty propagation methods for full model uncertainty

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,7 +9,7 @@ repos:
     -   id: mypy
         name: mypy with Python 3.12
         files: src/cabinetry
-        additional_dependencies: ["numpy>=1.22", "boost-histogram>=1.0.1", "click>=8", "types-tabulate", "types-PyYAML", "hist>=2.3.0"]
+        additional_dependencies: ["numpy>=1.22", "boost-histogram>=1.0.1", "click>=8", "types-tabulate", "types-PyYAML", "hist>=2.3.0","jacobi"]
         args: ["--python-version=3.12"]
 -   repo: https://github.com/pycqa/flake8
     rev: 7.1.2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ classifiers = [
 ]
 dependencies = [
     "pyhf[minuit]~=0.7.0",  # model.config.suggested_fixed / .par_names API changes, set_poi(None)
+    "jacobi",
     "boost_histogram>=1.0.0",  # subclassing with family, 1.02 for stdev scaling fix (currently not needed)
     "hist>=2.5.0",  # hist.intervals.poisson_interval
     "tabulate>=0.8.1",  # multiline text

--- a/src/cabinetry/model_utils.py
+++ b/src/cabinetry/model_utils.py
@@ -267,7 +267,10 @@ def yield_stdev(
               over all samples)
     """
     if model_unc_method not in ["linear", "jacobi", "bootstrap"]:
-        raise ValueError("model_unc_method must be 'linear', 'jacobi' or 'bootstrap'")
+        raise ValueError(
+            f"model uncertainty method {model_unc_method} not supported, "
+            "use 'linear', 'jacobi' or 'bootstrap'"
+        )
     # check whether results are already stored in cache
     cached_results = _YIELD_STDEV_CACHE.get(
         (

--- a/tests/test_model_utils.py
+++ b/tests/test_model_utils.py
@@ -248,6 +248,7 @@ def test_yield_stdev(example_spec, example_spec_multibin):
         tuple(parameters),
         tuple(uncertainty),
         corr_mat.tobytes(),
+        "linear",
     ]
     for i_reg in range(2):
         assert np.allclose(from_cache[0][i_reg], expected_stdev_bin[i_reg])
@@ -309,7 +310,12 @@ def test_prediction(
     assert np.allclose(
         mock_stdev.call_args_list[0][0][3], np.diagflat([1.0, 1.0, 1.0, 1.0])
     )
-    assert mock_stdev.call_args_list[0][1] == {}
+    assert mock_stdev.call_args_list[0][1] == {
+        "model_unc_method": "linear",
+        "minuit_obj": None,
+        "bootstrap_seed": 1,
+        "bootstrap_size": 1000,
+    }
 
     # post-fit prediction, single-channel model
     model = pyhf.Workspace(example_spec).model()
@@ -341,7 +347,12 @@ def test_prediction(
     assert np.allclose(
         mock_stdev.call_args_list[1][0][3], np.asarray([[1.0, 0.2], [0.2, 1.0]])
     )
-    assert mock_stdev.call_args_list[1][1] == {}
+    assert mock_stdev.call_args_list[1][1] == {
+        "model_unc_method": "linear",
+        "minuit_obj": None,
+        "bootstrap_seed": 1,
+        "bootstrap_size": 1000,
+    }
 
     caplog.clear()
 


### PR DESCRIPTION
Closes #221.
Blocked by #505.
This PR implements two alternative methods to propagate parameter uncertainties to a model, following the discussion in #221. The two implemented methods are:

- Error propagation by using the model's Jacobian (with finite-differences for derivatives) as implemented by `iminuit`
- Error estimation by bootstrapping the model predictions

Both methods can be accessed from the `model_utils.yield_stdev` function directly, or via the `model_utils.prediction` method. In both cases, the user simply specifies the name of the method that should be used for propagating the uncertainty. In case of bootstrapping, the user can also specify the seed for the bootstrap random number generator and the number of samples to be produced. 

To-do:
- [x] initial implementation of Jacobi method
- [x] initial implementation of bootstrap method
- [x] consistent variance array across all three methods of array propagation and harmonise transforming that to per-bin and per-channel quantities
- [ ] Modularise the code by splitting the methods into individual functions
- [ ] Wrap some common operations into modular methods
- [x] Add tests
- [x] Test closure in a model where closure is expected (model linear in all parameters, norm factors-only setup, all mods are linearly interpolated,..)  -- See [scikit-hep/pyhf/#2584](https://github.com/scikit-hep/pyhf/discussions/2584)