### PR TITLE
fix: type ignores for numpy 2.3

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,7 +9,7 @@ repos:
     -   id: mypy
         name: mypy with Python 3.12
         files: src/cabinetry
-        additional_dependencies: ["numpy>=1.22", "boost-histogram>=1.0.1", "click>=8", "types-tabulate", "types-PyYAML", "hist>=2.3.0"]
+        additional_dependencies: ["numpy>=2.3.0", "boost-histogram>=1.0.1", "click>=8", "types-tabulate", "types-PyYAML", "hist>=2.3.0"]
         args: ["--python-version=3.12"]
 -   repo: https://github.com/pycqa/flake8
     rev: 7.1.2

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@ repos:
     hooks:
     -   id: black
 -   repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.15.0
+    rev: v1.16.1
     hooks:
     -   id: mypy
         name: mypy with Python 3.12
@@ -12,12 +12,12 @@ repos:
         additional_dependencies: ["numpy>=2.3.0", "boost-histogram>=1.0.1", "click>=8", "types-tabulate", "types-PyYAML", "hist>=2.3.0"]
         args: ["--python-version=3.12"]
 -   repo: https://github.com/pycqa/flake8
-    rev: 7.1.2
+    rev: 7.3.0
     hooks:
     -   id: flake8
         additional_dependencies: [flake8-bugbear, flake8-import-order, flake8-print]
 -   repo: https://github.com/asottile/pyupgrade
-    rev: v3.19.1
+    rev: v3.20.0
     hooks:
     -   id: pyupgrade
         args: ["--py38-plus"]

--- a/src/cabinetry/histo.py
+++ b/src/cabinetry/histo.py
@@ -142,7 +142,7 @@ class Histogram(bh.Histogram, family=cabinetry):
         Args:
             value (np.ndarray): yields to set
         """
-        self.view().value = value  # type: ignore[union-attr]
+        self.view().value = value  # type: ignore[attr-defined]
 
     @property
     def stdev(self) -> np.ndarray:
@@ -160,7 +160,7 @@ class Histogram(bh.Histogram, family=cabinetry):
         Args:
             value (np.ndarray): the standard deviation
         """
-        self.view().variance = value**2  # type: ignore[misc,union-attr]
+        self.view().variance = value**2  # type: ignore[attr-defined]
 
     @property
     def bins(self) -> np.ndarray:


### PR DESCRIPTION
Version [2.3.0](https://github.com/numpy/numpy/releases/tag/v2.3.0) of `numpy` brought some typing changes that require small adjustments to some type ignores we have in place (some more context about them is in #204 and https://github.com/scikit-hep/boost-histogram/issues/527). This update allows pre-commit CI to pass `mypy` again.

```
* type ignores updated for compatibility with numpy 2.3.0
* updated pre-commit
```