### PR TITLE
test: better log level for histogram test

### DIFF
--- a/tests/test_histo.py
+++ b/tests/test_histo.py
@@ -180,7 +180,7 @@ def test_Histogram_save(tmp_path, example_histograms, histogram_helpers):
 
 
 def test_Histogram_validate(caplog, example_histograms):
-    caplog.set_level(logging.DEBUG)
+    caplog.set_level(logging.INFO)
     name = "test_histo"
 
     # should cause no warnings


### PR DESCRIPTION
https://github.com/scikit-hep/boost-histogram/pull/1036 added some DEBUG level outputs to `boost-histogram` which caused a test to fail in nightly `cabinetry` CI. There is no need to check logs from external libraries at the DEBUG level for this test, so we can change to INFO.

```
* raise log level to INFO in histogram test
```