### PR TITLE
test: temporarily skip pytorch in tests

### DIFF
--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -16,7 +16,7 @@ def reset_backend():
 
 @pytest.mark.slow
 @pytest.mark.no_cover
-@pytest.mark.parametrize("backend", ["jax", "pytorch"])  # skip TF temporarily
+@pytest.mark.parametrize("backend", ["jax"])  # skip TF & pytorch temporarily
 def test_backend_integration(backend, reset_backend):
     """Integration test for the inference pipeline that can be run with all ``pyhf``
     backends to ensure they work. ``typeguard`` will catch type issues at runtime.


### PR DESCRIPTION
A former `DeprecationWarning` when using the `pytorch` backend in `pyhf` has now turned into a `TypeError`. Temporarily skip this backends in tests until fixed upstream, tracked via https://github.com/scikit-hep/pyhf/issues/2554. This is similar to #468 disabling TensorFlow.

```
* temporarily skip pytorch backend in tests
```