### PR TITLE
fix: address matplotlib typing issues and remove unnecessary casts

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,7 +9,7 @@ repos:
     -   id: mypy
         name: mypy with Python 3.14
         files: src/cabinetry
-        additional_dependencies: ["numpy>=2.3.0", "boost-histogram>=1.0.1", "click>=8", "types-tabulate", "types-PyYAML", "hist>=2.3.0"]
+        additional_dependencies: ["numpy>=2.3.0", "boost-histogram>=1.0.1", "click>=8", "types-tabulate", "types-PyYAML", "hist>=2.3.0", "matplotlib>=3.10.0"]
         args: ["--python-version=3.14"]
 -   repo: https://github.com/pycqa/flake8
     rev: 7.3.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -138,7 +138,7 @@ files = "src/cabinetry"
 pretty = true
 show_error_context = true
 show_error_codes = true
-enable_error_code = ["ignore-without-code", "redundant-expr", "truthy-bool"]
+enable_error_code = ["ignore-without-code", "redundant-expr", "truthy-bool", "type-arg"]
 # strict = true
 disallow_untyped_calls = true
 disallow_untyped_defs = true
@@ -151,6 +151,7 @@ warn_unreachable = true
 warn_unused_ignores = true
 strict_equality = true
 no_implicit_optional = true
+implicit_reexport = false
 python_version = "3.10"
 
 [[tool.mypy.overrides]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -157,7 +157,6 @@ python_version = "3.10"
 module = [
     "uproot",
     "pyhf",
-    "matplotlib.*",
     "iminuit",
     "jsonschema",
     "scipy.*",

--- a/src/cabinetry/fit/__init__.py
+++ b/src/cabinetry/fit/__init__.py
@@ -1,7 +1,7 @@
 """High-level entry point for statistical inference."""
 
 import logging
-from typing import Any, cast, Literal
+from typing import Any, Literal
 
 import iminuit
 import numpy as np
@@ -779,7 +779,7 @@ def scan(
     for i_par, par_value in enumerate(scan_values):
         log.debug(f"performing fit with {par_name} = {par_value:.3f}")
         init_pars_scan = init_pars.copy()
-        init_pars_scan[par_index] = cast(float, par_value)
+        init_pars_scan[par_index] = par_value
         scan_fit_results = _fit_model(
             model,
             data,

--- a/src/cabinetry/fit/__init__.py
+++ b/src/cabinetry/fit/__init__.py
@@ -11,11 +11,11 @@ import scipy.stats
 
 from cabinetry import model_utils
 from cabinetry.fit.results_containers import (
-    FitResults,
-    LimitResults,
-    RankingResults,
-    ScanResults,
-    SignificanceResults,
+    FitResults as FitResults,
+    LimitResults as LimitResults,
+    RankingResults as RankingResults,
+    ScanResults as ScanResults,
+    SignificanceResults as SignificanceResults,
 )
 
 log = logging.getLogger(__name__)
@@ -911,7 +911,8 @@ def limit(
         model.config.set_poi(original_model_poi_name)
         raise ValueError(f"the two bracket values must not be the same: {bracket}")
 
-    cache_CLs: dict[float, tuple] = {}  # cache storing all relevant results
+    # cache storing all relevant results
+    cache_CLs: dict[float, tuple[float, np.ndarray]] = {}
 
     def _cls_minus_threshold(
         poi_val: float,

--- a/src/cabinetry/model_utils.py
+++ b/src/cabinetry/model_utils.py
@@ -144,7 +144,7 @@ def model_and_data(
     asimov: bool = False,
     include_auxdata: bool = True,
     validate: bool = True,
-    modifier_set: dict[str, tuple] | None = None,
+    modifier_set: dict[str, tuple[Any, ...]] | None = None,
 ) -> tuple[pyhf.pdf.Model, list[float]]:
     """Returns model and data for a ``pyhf`` workspace specification.
 

--- a/src/cabinetry/model_utils.py
+++ b/src/cabinetry/model_utils.py
@@ -155,8 +155,8 @@ def model_and_data(
             True
         validate (bool, optional): whether to validate the workspace and model against
             the respective JSON schema, defaults to True
-        modifier_set (dict[str, tuple] | None, optional): additional custom modifiers
-            to support, defaults to None (no custom modifiers)
+        modifier_set (dict[str, tuple[Any, ...]] | None, optional): additional custom
+            modifiers to support, defaults to None (no custom modifiers)
 
     Returns:
         tuple[pyhf.pdf.Model, list[float]]: tuple containing a HistFactory-style model

--- a/src/cabinetry/model_utils.py
+++ b/src/cabinetry/model_utils.py
@@ -3,7 +3,7 @@
 from collections import defaultdict
 import json
 import logging
-from typing import Any, cast, NamedTuple
+from typing import Any, NamedTuple
 
 import numpy as np
 import pyhf
@@ -909,13 +909,9 @@ def _parameters_maximizing_constraint_term(
             else:
                 rescale_factors = [1.0] * n_params  # no rescaling by default
 
-            # manually cast, possible cause https://github.com/numpy/numpy/issues/27944
-            best_pars += cast(
-                list[float],
-                (
-                    np.asarray(aux_data[i_aux : i_aux + n_params]) / rescale_factors
-                ).tolist(),
-            )
+            best_pars += (
+                np.asarray(aux_data[i_aux : i_aux + n_params]) / rescale_factors
+            ).tolist()
             i_aux += n_params
 
         else:

--- a/src/cabinetry/visualize/plot_model.py
+++ b/src/cabinetry/visualize/plot_model.py
@@ -494,7 +494,7 @@ def modifier_grid(
             tick.set_horizontalalignment("right")
 
     # construct colobar with category labels
-    formatter = plt.FuncFormatter(lambda val, _: category_map[val])
+    formatter = mpl.ticker.FuncFormatter(lambda val, _: category_map[val])
     _ = fig.colorbar(
         im, ax=ax.ravel().tolist(), ticks=np.arange(len(category_map)), format=formatter
     )

--- a/src/cabinetry/visualize/plot_model.py
+++ b/src/cabinetry/visualize/plot_model.py
@@ -200,12 +200,12 @@ def data_mc(
     if log_scale or (log_scale is None and (y_max / y_min) > 100):
         # log vertical axis scale and limits
         ax1.set_yscale("log")
-        ax1.set_ylim([y_min / 10, y_max * 10])
+        ax1.set_ylim(y_min / 10, y_max * 10)
         # add "_log" to the figure name if figure should be saved
         figure_path = utils._log_figure_path(figure_path)
     else:
         # do not use log scale
-        ax1.set_ylim([0, y_max * 1.5])  # 50% headroom
+        ax1.set_ylim(0, y_max * 1.5)  # 50% headroom
 
     # log scale for horizontal axes
     if log_scale_x:
@@ -240,11 +240,11 @@ def data_mc(
     ax1.tick_params(direction="in", top=True, right=True, which="both")
 
     ax2.set_xlim(bin_edges[0], bin_edges[-1])
-    ax2.set_ylim([0.5, 1.5])
+    ax2.set_ylim(0.5, 1.5)
     ax2.set_xlabel(histogram_dict_list[0]["variable"])
     ax2.set_ylabel("data / model")
     ax2.set_yticks([0.5, 0.75, 1.0, 1.25, 1.5])
-    ax2.set_yticklabels([0.5, 0.75, 1.0, 1.25, ""])
+    ax2.set_yticklabels(["0.5", "0.75", "1.0", "1.25", ""])
     ax2.tick_params(axis="both", which="major", pad=8)
     ax2.tick_params(direction="in", top=True, right=True, which="both")
 
@@ -412,19 +412,19 @@ def templates(
 
     max_yield = max(max(template["yields"]) for template in all_templates if template)
 
-    ax1.set_xlim([bin_edges[0], bin_edges[-1]])
-    ax1.set_ylim([0, max_yield * 1.75])
+    ax1.set_xlim(bin_edges[0], bin_edges[-1])
+    ax1.set_ylim(0, max_yield * 1.75)
     ax1.set_ylabel("events")
     ax1.set_xticklabels([])
     ax1.tick_params(axis="both", which="major", pad=8)  # tick label - axis padding
     ax1.tick_params(direction="in", top=True, right=True, which="both")
 
-    ax2.set_xlim([bin_edges[0], bin_edges[-1]])
-    ax2.set_ylim([0.5, 1.5])
+    ax2.set_xlim(bin_edges[0], bin_edges[-1])
+    ax2.set_ylim(0.5, 1.5)
     ax2.set_xlabel(variable)
     ax2.set_ylabel(f"variation / {'nominal' if not neg_nom_bin else 'abs(nominal)'}")
     ax2.set_yticks([0.5, 0.75, 1.0, 1.25, 1.5])
-    ax2.set_yticklabels([0.5, 0.75, 1.0, 1.25, ""])
+    ax2.set_yticklabels(["0.5", "0.75", "1.0", "1.25", ""])
     ax2.tick_params(axis="both", which="major", pad=8)
     ax2.tick_params(direction="in", top=True, right=True, which="both")
 

--- a/src/cabinetry/visualize/plot_result.py
+++ b/src/cabinetry/visualize/plot_result.py
@@ -230,7 +230,7 @@ def ranking(
     ax_impact.tick_params(direction="in", which="both")
 
     fig.legend(
-        (pre_up, pre_down, post_up, post_down, pulls),
+        (pre_up, pre_down, post_up, post_down, pulls),  # type: ignore[arg-type]
         (
             r"pre-fit impact: $\theta = \hat{\theta} + \Delta \theta$",
             r"pre-fit impact: $\theta = \hat{\theta} - \Delta \theta$",

--- a/src/cabinetry/visualize/plot_result.py
+++ b/src/cabinetry/visualize/plot_result.py
@@ -94,9 +94,9 @@ def pulls(
     ax.fill_between([-1, 1], -0.5, len(bestfit) - 0.5, color="limegreen")
     ax.vlines(0, -0.5, len(bestfit) - 0.5, linestyles="dotted", color="black")
 
-    ax.set_xlim([-3, 3])
+    ax.set_xlim(-3, 3)
     ax.set_xlabel(r"$\left(\hat{\theta} - \theta_0\right) / \Delta \theta$")
-    ax.set_ylim([-0.5, num_pars - 0.5])
+    ax.set_ylim(-0.5, num_pars - 0.5)
     ax.set_yticks(y_positions)
     ax.set_yticklabels(labels)
     ax.xaxis.set_minor_locator(mpl.ticker.AutoMinorLocator())  # minor ticks
@@ -145,7 +145,7 @@ def ranking(
     # layout to make space for legend on top
     leg_space = 1.0 / (num_pars + 3) + 0.03
     layout = matplotlib.layout_engine.ConstrainedLayoutEngine(
-        rect=[0, 0, 1.0, 1 - leg_space]
+        rect=(0, 0, 1.0, 1 - leg_space)
     )
 
     mpl.style.use("petroff10")
@@ -199,9 +199,9 @@ def ranking(
 
     ax_pulls.set_xlabel(r"$\left(\hat{\theta} - \theta_0\right) / \Delta \theta$")
     ax_impact.set_xlabel(r"$\Delta \mu$")
-    ax_pulls.set_xlim([-2, 2])
-    ax_impact.set_xlim([-5, 5])
-    ax_pulls.set_ylim([-1, num_pars])
+    ax_pulls.set_xlim(-2, 2)
+    ax_impact.set_xlim(-5, 5)
+    ax_pulls.set_ylim(-1, num_pars)
 
     # impact axis limits: need largest impact
     # consider also post-fit, normalization factors have no pre-fit impact defined
@@ -217,7 +217,7 @@ def ranking(
             )
         )
     )
-    ax_impact.set_xlim([-impact_max * 1.1, impact_max * 1.1])
+    ax_impact.set_xlim(-impact_max * 1.1, impact_max * 1.1)
 
     # minor ticks
     for axis in [ax_pulls.xaxis, ax_impact.xaxis]:
@@ -408,8 +408,8 @@ def limit(
 
     ax.set_xlabel(r"$\mu$")
     ax.set_ylabel(r"$\mathrm{CL}_{s}$")
-    ax.set_xlim([xmin, xmax])
-    ax.set_ylim([0, 1])
+    ax.set_xlim(xmin, xmax)
+    ax.set_ylim(0, 1)
     ax.tick_params(axis="both", which="major", pad=8)
     ax.tick_params(direction="in", top=True, right=True, which="both")
 

--- a/src/cabinetry/workspace.py
+++ b/src/cabinetry/workspace.py
@@ -3,7 +3,7 @@
 import json
 import logging
 import pathlib
-from typing import Any, cast
+from typing import Any
 
 import pyhf
 
@@ -188,9 +188,8 @@ class WorkspaceBuilder:
         else:
             norm_effect_up = histogram_up.normalize_to_yield(histogram_nominal)
             norm_effect_down = histogram_down.normalize_to_yield(histogram_nominal)
-            # manually cast due to https://github.com/numpy/numpy/issues/27944
-            histo_yield_up = cast(list[float], histogram_up.yields.tolist())
-            histo_yield_down = cast(list[float], histogram_down.yields.tolist())
+            histo_yield_up = histogram_up.yields.tolist()
+            histo_yield_down = histogram_down.yields.tolist()
 
         log.debug(
             f"normalization impact of systematic {systematic['Name']} on sample "
@@ -507,12 +506,9 @@ def _symmetrized_templates_and_norm(
     # normalize the variation to the same yield as nominal
     norm_effect_var = variation.normalize_to_yield(reference)
     norm_effect_sym = 2 - norm_effect_var
-    # manually cast due to https://github.com/numpy/numpy/issues/27944
-    histo_yield_var = cast(list[float], variation.yields.tolist())
+    histo_yield_var = variation.yields.tolist()
     # need another histogram that corresponds to the symmetrized variation,
     # which is 2*nominal - variation
-    histo_yield_sym = cast(
-        list[float], (2 * reference.yields - variation.yields).tolist()
-    )
+    histo_yield_sym = (2 * reference.yields - variation.yields).tolist()
 
     return histo_yield_var, histo_yield_sym, norm_effect_var, norm_effect_sym

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -39,9 +39,7 @@ def test_cabinetry():
 @mock.patch("cabinetry.templates.collect", autospec=True)
 @mock.patch("cabinetry.templates.build", autospec=True)
 @mock.patch(
-    "cabinetry.configuration._input_is_ntuple",
-    side_effect=[True, False],
-    autospec=True,
+    "cabinetry.configuration._input_is_ntuple", side_effect=[True, False], autospec=True
 )
 @mock.patch("cabinetry.configuration.validate", autospec=True)
 def test_templates(


### PR DESCRIPTION
Add `matplotlib` to the `mypy` dependencies and fix all typing-related issues with `matplotlib`. There is one new `# type: ignore` for which I found no better solution. A few `cast` instances are also no longer needed, so removing those. Additionally, set two more optional `mypy` configuration options on the way towards strict mode: enable [`type-arg`](https://mypy.readthedocs.io/en/stable/error_code_list2.html#check-that-type-arguments-exist-type-arg) and disable [`implicit-reexport`](https://mypy.readthedocs.io/en/stable/config_file.html#confval-implicit_reexport).

Following this, the only remaining things flagged by `mypy --strict` are of kind [`warn_return_any`](https://mypy.readthedocs.io/en/stable/config_file.html#confval-warn_return_any).

```
* add matplotlib to mypy dependencies
* fix matplotlib typing issues
* enable type-arg and disable implicit_reexport for mypy
* remove superfluous instances of cast()
```