### PR TITLE
test: add missing asserts and fix mock return types

### DIFF
--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -279,10 +279,10 @@ def test_integration(tmp_path, ntuple_creator, caplog):
 
     # discovery significance
     significance_results = cabinetry.fit.significance(model, data)
-    np.allclose(significance_results.observed_p_value, 0.03583662)
-    np.allclose(significance_results.observed_significance, 1.80118813)
-    np.allclose(significance_results.expected_p_value, 0.14775040)
-    np.allclose(significance_results.expected_significance, 1.04613046)
+    assert np.allclose(significance_results.observed_p_value, 0.03583662)
+    assert np.allclose(significance_results.observed_significance, 1.80118813)
+    assert np.allclose(significance_results.expected_p_value, 0.14775040)
+    assert np.allclose(significance_results.expected_significance, 1.04613046)
 
 
 @pytest.mark.no_cover

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -532,22 +532,22 @@ def test_WorkspaceBuilder_observations(mock_histogram):
 
 @mock.patch(
     "cabinetry.workspace.WorkspaceBuilder.observations",
-    return_value=[{"name: observations"}],
+    return_value=[{"name": "observations"}],
 )
 @mock.patch(
     "cabinetry.workspace.WorkspaceBuilder.measurements",
-    return_value=[{"name: measurement"}],
+    return_value=[{"name": "measurement"}],
 )
 @mock.patch(
-    "cabinetry.workspace.WorkspaceBuilder.channels", return_value=[{"name: channel"}]
+    "cabinetry.workspace.WorkspaceBuilder.channels", return_value=[{"name": "channel"}]
 )
 def test_WorkspaceBuilder_build(mock_channels, mock_measuremets, mock_observations):
     ws_builder = workspace.WorkspaceBuilder({"General": {"HistogramFolder": "path"}})
     ws = ws_builder.build()
     ws_expected = {
-        "channels": [{"name: channel"}],
-        "measurements": [{"name: measurement"}],
-        "observations": [{"name: observations"}],
+        "channels": [{"name": "channel"}],
+        "measurements": [{"name": "measurement"}],
+        "observations": [{"name": "observations"}],
         "version": "1.0.0",
     }
     assert ws == ws_expected


### PR DESCRIPTION
Fixing two things spotted in tests: the significance integration test was missing some asserts and the return types in a workspace building test should be dicts (but since this is all mocked, the test does not really change).

```
* add missing asserts to integration test
* fix return type of mock in workspace builder test
```