### PR TITLE
fix: validate post-processed histograms

### DIFF
--- a/src/cabinetry/templates/postprocessor.py
+++ b/src/cabinetry/templates/postprocessor.py
@@ -178,7 +178,7 @@ def _postprocessor(histogram_folder: pathlib.Path) -> route.ProcessorFunc:
             smoothing_algorithm=smoothing_algorithm,
             nominal_histogram=nominal_histogram,
         )
-        histogram.validate(histogram_name)
+        new_histogram.validate(histogram_name)
         new_histo_path = histogram_folder / (histogram_name + "_modified")
         new_histogram.save(new_histo_path)
 

--- a/tests/templates/test_templates_postprocessor.py
+++ b/tests/templates/test_templates_postprocessor.py
@@ -169,6 +169,10 @@ def test__postprocessor(mock_name):
                 )
             ]  # postprocessing was executed
 
+            assert mock_new_histogram.validate.call_args_list == [
+                (("histo_name",), {})
+            ]  # new histogram was validated
+
             assert mock_new_histogram.save.call_args_list == [
                 ((pathlib.Path("path/histo_name_modified"),), {})
             ]  # new histogram was saved (meaning right name was obtained)


### PR DESCRIPTION
Histogram validation was called during post-processing on the input histograms, not the post-processed version. This fixes the behavior to run over the final post-processed histogram instead. As the validation only logs warnings, this has no effect beyond logging.

```
* fix histogram validation in post-processing to run over final histogram instead of original
```